### PR TITLE
N+1クエリ修正とサービスオブジェクト抽出によるリファクタリング

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -20,23 +20,12 @@ class Api::TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(create_params)
-    id = Area.get_area_id(create_params[:task_title])
+    result = TaskCreationService.new(task_title: create_params[:task_title]).call
 
-    if id.nil?
-      render json: { message: "エリアが正しく設定されていない" }, status: 400
+    if result.success?
+      render json: result.task
     else
-      task.area_id = id
-      if task.save
-        cycle = task.create_new_cycle
-        if cycle.assign
-          render json: task
-        else
-          render json: { status: 422 }, status: 422
-        end
-      else
-        render json: { message: task.errors.full_messages, status: 422 }, status: :unprocessable_entity
-      end
+      render json: { message: result.error_message, status: 422 }, status: result.error_status
     end
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -36,45 +36,70 @@ class Account < ApplicationRecord
     self.tags.destroy(tag)
   end
 
+  # 単一アカウントのステータスを取得（1クエリで集計）
   def get_status
-    total = AssignHistory.where(account_id: self.id)
-              .where(completed: true)
-              .count
-    week = AssignHistory.where("completed_at > ?", 1.week.ago)
-              .where(account_id: self.id)
-              .count
-    assign = AssignHistory.where(account_id: self.id)
-              .where(ng: false)
-              .where(completed: false)
-              .count
-    ng = AssignHistory.where(account_id: self.id).where(ng: true).count
+    stats = AssignHistory.where(account_id: id)
+              .select(
+                "COUNT(CASE WHEN completed = true THEN 1 END) AS total_count",
+                "COUNT(CASE WHEN completed_at > '#{1.week.ago.to_fs(:db)}' THEN 1 END) AS week_count",
+                "COUNT(CASE WHEN ng = false AND completed = false THEN 1 END) AS assign_count",
+                "COUNT(CASE WHEN ng = true THEN 1 END) AS ng_count"
+              ).take
 
-    # ゼロ除算を避けるため、totalが0の場合はng_rateを0.0に設定
-    ng_rate = total.zero? ? 0.0 : (ng.to_f / total).floor(2)
+    total = stats&.total_count.to_i
+    ng_count = stats&.ng_count.to_i
+    ng_rate = total.zero? ? 0.0 : (ng_count.to_f / total).floor(2)
 
     {
-      id: self.id,
-      capacity: self.capacity,
-      createdAt: self.created_at,
-      updatedAt: self.updated_at,
-      name: self.name,
-      area: self.areas.pluck(:name),
+      id:,
+      capacity:,
+      createdAt: created_at,
+      updatedAt: updated_at,
+      name:,
+      area: areas.pluck(:name),
       total:,
-      week:,
+      week: stats&.week_count.to_i,
       ng_rate:,
-      assign:
+      assign: stats&.assign_count.to_i
     }
   end
 
   class << self
+    # 全メンバーのステータスをバッチ取得（N+1を回避）
     def get_role_one_status
-      res = []
+      members = Account.where(role: "member").includes(:areas)
 
-      Account.where(role: "member").each do |ele|
-        res.push(ele.get_status)
+      # 全メンバーの統計を一括取得
+      stats_by_account = AssignHistory
+        .where(account_id: members.pluck(:id))
+        .group(:account_id)
+        .select(
+          :account_id,
+          "COUNT(CASE WHEN completed = true THEN 1 END) AS total_count",
+          "COUNT(CASE WHEN completed_at > '#{1.week.ago.to_fs(:db)}' THEN 1 END) AS week_count",
+          "COUNT(CASE WHEN ng = false AND completed = false THEN 1 END) AS assign_count",
+          "COUNT(CASE WHEN ng = true THEN 1 END) AS ng_count"
+        ).index_by(&:account_id)
+
+      members.map do |account|
+        stats = stats_by_account[account.id]
+        total = stats&.total_count.to_i
+        ng_count = stats&.ng_count.to_i
+        ng_rate = total.zero? ? 0.0 : (ng_count.to_f / total).floor(2)
+
+        {
+          id: account.id,
+          capacity: account.capacity,
+          createdAt: account.created_at,
+          updatedAt: account.updated_at,
+          name: account.name,
+          area: account.areas.map(&:name),
+          total:,
+          week: stats&.week_count.to_i,
+          ng_rate:,
+          assign: stats&.assign_count.to_i
+        }
       end
-
-      res
     end
   end
 end

--- a/app/models/assign_cycle.rb
+++ b/app/models/assign_cycle.rb
@@ -4,51 +4,18 @@ class AssignCycle < ApplicationRecord
   has_many :assign_histories
   has_many :comments
 
-  # キャパシティの何倍まで許容するか
-  CAPACITY_MULTIPLIER = 4
-
-
   def assign
-    accounts = get_assignable
-
+    accounts = AssignableAccountsService.new(assign_cycle: self).call
     target = accounts.first
 
-    if target == nil
-      return false
-    end
+    return false if target.nil?
 
-    current_assign = AssignHistory.new(account_id: target.id, assign_cycle_id: self.id)
-
-    if current_assign.save
-      current_assign
-    else
-      false
-    end
+    current_assign = AssignHistory.new(account_id: target.id, assign_cycle_id: id)
+    current_assign.save ? current_assign : false
   end
 
   def get_assignable
-    task = self.try(:task)
-
-    # 既にこのcycleでにNGがついているAccountを取得
-    assigned = Account.left_joins(assign_histories: :assign_cycle)
-                  .where(assign_cycles: { id: self.id })
-
-    # アサインされているタスク数がキャパシティの#{CAPACITY_MULTIPLIER}倍以上になっているAccountを取得する
-    over_cap = Account.joins(:areas)
-                  .left_outer_joins(assign_histories: :assign_cycle)
-                  .group("accounts.id")
-                  .where(areas: { id: task.area.id })
-                  .where("assign_histories.ng = false OR assign_histories.ng IS NULL")
-                  .where("assign_histories.completed = false OR assign_histories.completed IS NULL")
-                  .having("COUNT(assign_histories.id) >= accounts.capacity * ?", CAPACITY_MULTIPLIER)
-
-    # エリア合致、未アサイン、キャパ範囲内、の3つの条件を満たす最初のAccountにアサイン
-    accounts = Account.joins(:areas)
-                  .where(areas: { id: task.area.id })
-                  .where.not(id: assigned.select(:id))
-                  .where.not(id: over_cap.select(:id))
-
-    accounts
+    AssignableAccountsService.new(assign_cycle: self).call
   end
 
   def completed

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -18,13 +18,10 @@ class Task < ApplicationRecord
   end
 
   def create_new_cycle
-    # すでにcycleが存在している場合非アクティブ化
-    AssignCycle.where(task_id: self.id).each do |cycle|
-      cycle.deactivation
-    end
+    # すでにcycleが存在している場合、一括で非アクティブ化
+    AssignCycle.where(task_id: id).update_all(is_active: false)
 
-    cycle = self.assign_cycles.create
-    cycle
+    assign_cycles.create
   end
 
   class << self

--- a/app/services/assignable_accounts_service.rb
+++ b/app/services/assignable_accounts_service.rb
@@ -1,0 +1,39 @@
+class AssignableAccountsService
+  # キャパシティの何倍まで許容するか
+  CAPACITY_MULTIPLIER = 4
+
+  def initialize(assign_cycle:)
+    @assign_cycle = assign_cycle
+    @task = assign_cycle.task
+  end
+
+  def call
+    return Account.none unless @task
+
+    area_id = @task.area_id
+
+    # 既にこのcycleでアサインされた（NGを含む）Accountを除外
+    assigned_account_ids = Account
+      .joins(assign_histories: :assign_cycle)
+      .where(assign_cycles: { id: @assign_cycle.id })
+      .select(:id)
+
+    # キャパシティオーバーのAccountを除外
+    over_capacity_account_ids = Account
+      .joins(:areas)
+      .left_outer_joins(assign_histories: :assign_cycle)
+      .where(areas: { id: area_id })
+      .where("assign_histories.ng = false OR assign_histories.ng IS NULL")
+      .where("assign_histories.completed = false OR assign_histories.completed IS NULL")
+      .group("accounts.id")
+      .having("COUNT(assign_histories.id) >= accounts.capacity * ?", CAPACITY_MULTIPLIER)
+      .select(:id)
+
+    # エリア合致、未アサイン、キャパ範囲内のAccountを取得
+    Account
+      .joins(:areas)
+      .where(areas: { id: area_id })
+      .where.not(id: assigned_account_ids)
+      .where.not(id: over_capacity_account_ids)
+  end
+end

--- a/app/services/task_creation_service.rb
+++ b/app/services/task_creation_service.rb
@@ -1,0 +1,41 @@
+class TaskCreationService
+  Result = Struct.new(:success?, :task, :error_message, :error_status, keyword_init: true)
+
+  def initialize(task_title:)
+    @task_title = task_title
+  end
+
+  def call
+    area_id = Area.get_area_id(@task_title)
+
+    if area_id.nil?
+      return Result.new(
+        success?: false,
+        error_message: "エリアが正しく設定されていない",
+        error_status: :bad_request
+      )
+    end
+
+    task = Task.new(task_title: @task_title, area_id:)
+
+    unless task.save
+      return Result.new(
+        success?: false,
+        error_message: task.errors.full_messages,
+        error_status: :unprocessable_entity
+      )
+    end
+
+    cycle = task.create_new_cycle
+    unless cycle.assign
+      return Result.new(
+        success?: false,
+        task:,
+        error_message: "アサイン可能なアカウントがありません",
+        error_status: :unprocessable_entity
+      )
+    end
+
+    Result.new(success?: true, task:)
+  end
+end


### PR DESCRIPTION
@codex review
- Account#get_status: 4つの個別クエリを1つのCASE WHEN集計に統合
- Account.get_role_one_status: N*5クエリをバッチ処理で2クエリに最適化
- Task#create_new_cycle: eachループをupdate_allに置き換え
- TaskCreationService: タスク作成ロジックをコントローラーから抽出
- AssignableAccountsService: アサイン可能アカウント取得ロジックをモデルから抽出