### PR TITLE
db/seeds.rbの削除済みメソッド呼び出しを修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,10 +28,10 @@ end
 
     h = c.assign
 
-    if h
-      if rand < 0.5
-        c.completed_test
-      end
+    if h && rand < 0.5
+      # シードデータ用：ランダムな過去日付で完了処理
+      h.update(completed: true, completed_at: Date.today - rand(1..7))
+      c.deactivation
     end
   end
 end


### PR DESCRIPTION
@codex review
変更内容:
- completed_testメソッド呼び出しを削除済みメソッドから直接更新処理に変更
- AssignHistory#updateで完了フラグとランダムな過去日付を直接設定
- AssignCycle#deactivationで非アクティブ化

変更理由:
- コミット19fb7f6で本番コードからテスト用メソッド(completed_test)が削除された
- seeds.rbが更新されておらず、db:seed実行時にNoMethodErrorが発生していた
- モデルにテスト用メソッドを戻さず、seeds.rb内で完結する形で修正

影響範囲:
- db/seeds.rbのみ。モデルやコントローラーへの変更なし
- シードデータ生成時の完了処理ロジックのみ影響

テスト結果:
- db:reset: 成功
- rspec: 96 examples, 0 failures
- rubocop: no offenses detected