### PR TITLE
開発環境の設定を改善

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,9 +8,11 @@ services:
       - ../..:/workspaces:cached
     environment:
       TZ: Asia/Tokyo
+    depends_on:
+      - db
 
     # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity
+    command: bash -c "rails db:create && rails db:migrate && sleep infinity"
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
 
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+CLAUDE*
+.claude/

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,8 @@ Rails.application.configure do
 
   config.hosts << "photo-in-backend_devcontainer-api-1:8000"
   config.enable_reloading = true
+  config.hosts << "api:3000"
+  config.hosts << "api"
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -34,10 +34,14 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-app_path = File.expand_path("..", __dir__)
-directory app_path
-pidfile "#{app_path}/tmp/pids/puma.pid"
-state_path "#{app_path}/tmp/pids/puma.state"
-threads 0, 16
-bind "unix://#{app_path}/tmp/sockets/puma.sock"
-activate_control_app
+# 本番環境のみUnixソケットバインドを使用（Nginx経由）
+# 開発環境ではポート3000でリッスン
+if ENV["RAILS_ENV"] == "production"
+  app_path = File.expand_path("..", __dir__)
+  directory app_path
+  pidfile "#{app_path}/tmp/pids/puma.pid"
+  state_path "#{app_path}/tmp/pids/puma.state"
+  threads 0, 16
+  bind "unix://#{app_path}/tmp/sockets/puma.sock"
+  activate_control_app
+end


### PR DESCRIPTION
変更内容:
- docker-compose.yml: depends_onでDB起動順序を保証、起動時にDB自動セットアップ
- .gitignore: Claude Code関連ファイル(CLAUDE*, .claude/)を除外
- development.rb: Dockerコンテナ間通信用ホスト(api:3000, api)を許可
- puma.rb: 本番環境のみUnixソケット使用、開発環境はポート直接リッスン

変更理由:
- DevContainer起動時のDB接続エラーを防止
- Claude Codeの設定ファイルをリポジトリから除外
- Docker環境でのAPI接続を許可
- 開発環境でPumaが正常に起動するよう設定を分離