### PR TITLE
refactor: Contracts層を新設しValidator層と責務分離

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,374 @@
+# ARCHITECTURE
+
+## 概要
+
+本ドキュメントは、本アプリケーションにおける **Rails 7（Zeitwerk）前提のアーキテクチャ方針** を定義する。
+
+目的は以下の通り。
+
+* 業務ロジックの肥大化・密結合を防ぐ
+* autoload / eager_load の事故を防ぐ
+* 副作用と純粋ロジックを分離する
+* テスト容易性・変更耐性を高める
+
+本アプリケーションでは、主に以下の 4 レイヤを中心に設計する。
+
+* Service（ユースケース層）
+* Domain（業務ルール層）
+* Contract（入力契約層）
+* Validator（入力検証層）
+
+---
+
+## 前提
+
+* Rails 7.x
+* Autoloader: Zeitwerk
+* `require` を書かない
+* 定数名とファイルパスは 1 対 1 対応
+
+---
+
+## ディレクトリ構成
+
+すべて `app/` 配下に配置し、Zeitwerk の自動認識に委ねる。
+
+```
+app/
+  contracts/     # 入力契約（検証 + データ変換）
+  domain/        # 業務ルール（pure）
+  services/      # ユースケース（副作用の統括）
+  validators/    # 入力検証（ActiveModel::Validator）
+```
+
+### 方針
+
+* `lib/` は原則使用しない
+* autoload 対象は `app/` のみとする
+* 命名規約を厳守する
+
+---
+
+## レイヤ責務
+
+### Domain（ドメイン層）
+
+#### 役割
+
+* 業務ルール・仕様の表現
+* **副作用を持たない純粋なロジック**
+* Rails / ActiveRecord / 外部API に依存しない
+
+#### 禁止事項
+
+* DB アクセス
+* HTTP / Mail / Job
+* ActiveRecord
+* Rails 固有 API
+
+#### 内容例
+
+* 状態遷移ルール
+* 可否判定
+* 計算ロジック
+* ポリシー・ルールセット
+
+#### 命名規約
+
+```
+app/domain/task/state_machine.rb
+→ Domain::Task::StateMachine
+```
+
+---
+
+### Service（サービス層 / ユースケース）
+
+#### 役割
+
+* ユースケースの実装
+* 副作用のオーケストレーション
+* トランザクション境界
+
+#### 許可事項
+
+* DB 更新
+* トランザクション制御
+* Domain 呼び出し
+* Validator / Form 利用
+
+#### 禁止事項
+
+* 業務ルールの直接実装（Domain に委譲）
+* Controller ロジックの肥大化
+
+#### 命名規約
+
+```
+app/services/task/complete.rb
+→ Services::Task::Complete
+```
+
+#### 戻り値ポリシー
+
+* 例外をそのまま返さない
+* 成功 / 失敗を Result オブジェクトで表現する
+
+---
+
+### Validator（入力検証層）
+
+#### 役割
+
+* 入力値の形式的妥当性を保証する
+* ActiveModel::Validator に準拠
+* **再利用可能な単一検証ロジック**
+
+#### 扱う内容
+
+* フォーマット
+* 長さ
+* 必須チェック
+* 単項目検証
+
+#### 扱わない内容
+
+* 業務仕様上の可否
+* 状態遷移
+* DB 横断チェック（原則）
+
+---
+
+### Contract（入力契約層）
+
+#### 役割
+
+* Controller からの入力パラメータを受け取る
+* 複数の Validator を組み合わせて検証を実行
+* 検証済みデータの正規化・変換
+* Result オブジェクトで成功/失敗を表現
+
+#### 許可事項
+
+* ActiveModel::Model による検証定義
+* Validator の利用（validates_with）
+* データ変換（型変換、正規化）
+
+#### 禁止事項
+
+* DB アクセス
+* 業務ロジックの実装（Domain に委譲）
+* 副作用を伴う処理
+
+#### 命名規約
+
+```
+app/contracts/<context>/<action>.rb
+→ Contracts::<Context>::<Action>
+```
+
+#### 例
+
+```
+app/contracts/accounts/create.rb
+→ Contracts::Accounts::Create
+
+app/contracts/tasks/update.rb
+→ Contracts::Tasks::Update
+```
+
+#### 戻り値ポリシー
+
+* `Contracts::Result` を使用する
+* `success?` / `value` / `errors` を持つ Struct
+
+---
+
+## 命名規約
+
+本アプリケーションでは、**ディレクトリ構成と定数名を厳密に対応**させることで、
+Zeitwerk による autoload の安全性と可読性を担保する。
+
+### 基本ルール
+
+* ファイルパス = 定数名（1 対 1 対応）
+* トップレベル定数は定義しない（必ず名前空間を切る）
+* 省略語・略称は使用しない（例: `Svc`, `Mgr` などは禁止）
+
+---
+
+### Service の命名規約
+
+**ユースケース単位で 1 Service** を原則とする。
+
+#### 形式
+
+```
+app/services/<context>/<action>.rb
+→ Services::<Context>::<Action>
+```
+
+#### Action 命名指針
+
+* `Create`   : 新規作成
+* `Update`   : 更新
+* `Delete`   : 削除
+* `Complete` : 完了・確定
+* `Execute`  : 手続き的処理（副作用が多い場合）
+
+#### 例
+
+```
+app/services/task/complete.rb
+→ Services::Task::Complete
+
+app/services/user/register.rb
+→ Services::User::Register
+```
+
+---
+
+### Domain の命名規約
+
+Domain は**業務概念・仕様単位**で命名する。
+
+#### 形式
+
+```
+app/domain/<context>/<concept>.rb
+→ Domain::<Context>::<Concept>
+```
+
+#### 命名指針
+
+* 動詞よりも名詞を優先する
+* `Rules` / `Policy` / `StateMachine` / `Calculator` などを明示する
+
+#### 例
+
+```
+app/domain/task/state_machine.rb
+→ Domain::Task::StateMachine
+
+app/domain/billing/price_calculator.rb
+→ Domain::Billing::PriceCalculator
+```
+
+---
+
+### Validator の命名規約
+
+Validator は **何を検証するかが一目で分かる名前** とする。
+
+#### 形式（フラット構造）
+
+```
+app/validators/<name>_validator.rb
+→ <Name>Validator
+```
+
+#### 形式（ネスト構造）
+
+コンテキストごとにグルーピングする場合：
+
+```
+app/validators/<context>/<name>.rb
+→ Validators::<Context>::<Name>
+```
+
+#### 命名指針
+
+* `Format` / `Presence` / `Length` / `Uniqueness` など目的を明示
+* 業務仕様を含む名称は禁止
+
+#### 例
+
+```
+app/validators/email_format_validator.rb
+→ EmailFormatValidator
+
+app/validators/accounts/create.rb
+→ Validators::Accounts::Create
+```
+
+---
+
+## 依存方向ルール
+
+依存関係は必ず以下を守る。
+
+```
+Contract  → Validator     OK
+Contract  → Domain        OK
+Service   → Contract      OK
+Service   → Domain        OK
+Service   → Validator     OK
+Validator → Domain        OK
+
+Domain    → Service       NG
+Domain    → Contract      NG
+Domain    → Validator     NG
+Domain    → ActiveRecord  NG
+Contract  → Service       NG
+Contract  → ActiveRecord  NG
+```
+
+Domain は最下層の純粋レイヤとする。
+Contract は入力層として Controller と Service の間に位置する。
+
+---
+
+## Controller / Model の責務
+
+### Controller
+
+* パラメータ取得
+* Contract による入力検証
+* Service 呼び出し
+* 結果に応じたレスポンス生成
+
+### Model（ActiveRecord）
+
+* 永続化
+* 関連定義
+* scope
+* 業務ロジックは極力持たせない
+
+---
+
+## autoload 安全性
+
+### チェック
+
+```
+bin/rails zeitwerk:check
+```
+
+### よくある NG
+
+* ファイル名と定数名の不一致
+* module ネスト不足
+* トップレベル定数の乱立
+
+---
+
+## 設計判断チェックリスト
+
+* DB に触るか？ → Service
+* 計算・判定のみか？ → Domain
+* 入力の形式チェックか？ → Validator
+* 入力検証 + データ変換か？ → Contract
+* トランザクション境界か？ → Service
+* 業務仕様か？ → Domain
+
+---
+
+## 設計思想まとめ
+
+* 副作用は Service に閉じ込める
+* 業務ルールは Domain に集約する
+* 入力検証とデータ変換は Contract で統括する
+* 単一の検証ロジックは Validator に切り出す
+* autoload は app/ 配下 + 命名規約で守る
+
+本方針に従うことで、変更に強く、壊れにくく、テストしやすい Rails アプリケーションを実現する。

--- a/app/contracts/accounts/create.rb
+++ b/app/contracts/accounts/create.rb
@@ -1,0 +1,47 @@
+module Contracts
+  module Accounts
+    class Create
+      include ActiveModel::Model
+
+      attr_accessor :name, :password, :role, :capacity, :area
+
+      validates :name, presence: true, length: { maximum: 32 }
+      validates :password, presence: true, length: { minimum: 8 }
+      validates :role, presence: true, inclusion: { in: %w[admin member] }
+      validates :capacity, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+
+      validates_with Validators::Accounts::Create
+
+      def self.call(params)
+        contract = new(
+          name: params[:name],
+          password: params[:password],
+          role: params[:role],
+          capacity: params[:capacity],
+          area: params[:area]
+        )
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        {
+          name:,
+          password:,
+          role:,
+          capacity: capacity.present? ? capacity.to_i : nil,
+          area_ids:
+        }
+      end
+
+      private
+        def area_ids
+          @area_ids ||= Array(area).compact.map(&:to_i)
+        end
+    end
+  end
+end

--- a/app/contracts/result.rb
+++ b/app/contracts/result.rb
@@ -1,0 +1,3 @@
+module Contracts
+  Result = Struct.new(:success?, :value, :errors, keyword_init: true)
+end

--- a/app/controllers/api/accounts_controller.rb
+++ b/app/controllers/api/accounts_controller.rb
@@ -18,7 +18,7 @@ class Api::AccountsController < ApplicationController
   end
 
   def create
-    validation = ::Validators::Accounts::Create.call(create_params.to_h.symbolize_keys)
+    validation = ::Contracts::Accounts::Create.call(create_params.to_h.symbolize_keys)
     unless validation.success?
       render json: { errors: validation.errors, status: 422 }, status: :unprocessable_entity
       return

--- a/app/validators/accounts/create.rb
+++ b/app/validators/accounts/create.rb
@@ -1,60 +1,25 @@
 module Validators
   module Accounts
-    Result = Struct.new(:success?, :value, :errors, keyword_init: true)
+    class Create < ActiveModel::Validator
+      AREA_ID_REGEX = /\A\d+\z/
 
-    class Create
-      include ActiveModel::Model
-
-      attr_accessor :name, :password, :role, :capacity, :area
-
-      validates :name, presence: true, length: { maximum: 32 }
-      validates :password, presence: true, length: { minimum: 8 }
-      validates :role, presence: true, inclusion: { in: %w[admin member] }
-      validates :capacity, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
-      validate :area_ids_format
-
-      def self.call(params)
-        contract = new(
-          name: params[:name],
-          password: params[:password],
-          role: params[:role],
-          capacity: params[:capacity],
-          area: params[:area]
-        )
-
-        if contract.valid?
-          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
-        else
-          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
-        end
-      end
-
-      def normalized_attributes
-        {
-          name:,
-          password:,
-          role:,
-          capacity: capacity.present? ? capacity.to_i : nil,
-          area_ids:
-        }
+      def validate(record)
+        validate_area(record)
       end
 
       private
-        def area_ids_format
+        def validate_area(record)
+          area = record.area
           return if area.nil?
 
           unless area.is_a?(Array)
-            errors.add(:area, "must be an array")
+            record.errors.add(:area, "must be an array")
             return
           end
 
-          return if area.all? { |id| id.to_s.match?(/\A\d+\z/) }
+          return if area.all? { |id| id.to_s.match?(AREA_ID_REGEX) }
 
-          errors.add(:area, "must contain only numeric ids")
-        end
-
-        def area_ids
-          @area_ids ||= Array(area).compact.map(&:to_i)
+          record.errors.add(:area, "must contain only numeric ids")
         end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,8 @@ module PhotoInBackend
       Rails.root.join("app/policies"),
       Rails.root.join("app/presenters"),
       Rails.root.join("app/services"),
-      Rails.root.join("app/domain")
+      Rails.root.join("app/domain"),
+      Rails.root.join("app/contracts")
     ]
     config.eager_load_paths += config.autoload_paths
 

--- a/config/initializers/autoload_paths.rb
+++ b/config/initializers/autoload_paths.rb
@@ -4,9 +4,11 @@ module Policies; end
 module Presenters; end
 module Services; end
 module Domain; end
+module Contracts; end
 
 Rails.autoloaders.main.push_dir(Rails.root.join("app/validators"), namespace: Validators)
 Rails.autoloaders.main.push_dir(Rails.root.join("app/policies"), namespace: Policies)
 Rails.autoloaders.main.push_dir(Rails.root.join("app/presenters"), namespace: Presenters)
 Rails.autoloaders.main.push_dir(Rails.root.join("app/services"), namespace: Services)
 Rails.autoloaders.main.push_dir(Rails.root.join("app/domain"), namespace: Domain)
+Rails.autoloaders.main.push_dir(Rails.root.join("app/contracts"), namespace: Contracts)

--- a/spec/contracts/accounts/create_contract_spec.rb
+++ b/spec/contracts/accounts/create_contract_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Contracts::Accounts::Create do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      let(:params) { { name: "Test", password: "password123", role: "member", area: [1, 2] } }
+
+      it "success?がtrueを返すこと" do
+        result = described_class.call(params)
+        expect(result.success?).to be true
+      end
+
+      it "normalized_attributesを返すこと" do
+        result = described_class.call(params)
+        expect(result.value[:area_ids]).to eq([1, 2])
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      let(:params) { { name: "", password: "short", role: "invalid" } }
+
+      it "success?がfalseを返すこと" do
+        result = described_class.call(params)
+        expect(result.success?).to be false
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = described_class.call(params)
+        expect(result.errors).to include("Name can't be blank")
+      end
+    end
+  end
+end

--- a/spec/validators/accounts/create_validator_spec.rb
+++ b/spec/validators/accounts/create_validator_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Validators::Accounts::Create do
+  let(:contract) { Contracts::Accounts::Create.new(area:) }
+
+  describe "#validate" do
+    context "areaが配列の場合" do
+      let(:area) { [1, 2, 3] }
+
+      it "エラーがないこと" do
+        contract.valid?
+        expect(contract.errors[:area]).to be_empty
+      end
+    end
+
+    context "areaが配列でない場合" do
+      let(:area) { "not_array" }
+
+      it "エラーを追加すること" do
+        contract.valid?
+        expect(contract.errors[:area]).to include("must be an array")
+      end
+    end
+
+    context "areaに数値以外が含まれる場合" do
+      let(:area) { [1, "abc", 3] }
+
+      it "エラーを追加すること" do
+        contract.valid?
+        expect(contract.errors[:area]).to include("must contain only numeric ids")
+      end
+    end
+  end
+end


### PR DESCRIPTION
変更内容:
- app/contracts/ ディレクトリを新設
- Contracts::Accounts::Create でバリデーション + データ変換を担当
- Validators::Accounts::Create を純粋なActiveModel::Validatorに変更
- Contracts::Result を共通戻り値型として定義
- ARCHITECTURE.md に Contracts レイヤーの方針を追記
- 単体テストを追加（7件）

変更理由:
- ARCHITECTURE.mdの方針に準拠した4層アーキテクチャの実現
- Validator層を純粋な入力検証に限定
- Contract層で入力検証とデータ変換を統括

影響範囲:
- POST /api/accounts（アカウント作成）
- autoload設定（Contractsネームスペース追加）
- ARCHITECTURE.md

テスト結果: Pass 103/103