### PR TITLE
refactor: Tasks indexを4層アーキテクチャに移行

### DIFF
--- a/app/contracts/tasks/index.rb
+++ b/app/contracts/tasks/index.rb
@@ -1,0 +1,25 @@
+module Contracts
+  module Tasks
+    class Index
+      include ActiveModel::Model
+
+      attr_accessor :type
+
+      validates :type, presence: true, inclusion: { in: %w[all ng] }
+
+      def self.call(params)
+        contract = new(type: params[:type])
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { type: }
+      end
+    end
+  end
+end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,17 +1,11 @@
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:create]
+  before_action :authenticated?, only: [:index, :create]
 
   def index
-    type = params[:type]
-
-    if type == "all"
-      tasks = Task.get_active_tasks
-      render json: tasks
-    elsif type == "ng"
-      tasks = Task.get_ng_tasks
-      render json: tasks
-    else
-      render json: { message: "not type" }
+    result = ::Services::Tasks::Index.new.call(index_params, @current_account)
+    render_result(result) do
+      presenter_method = params[:type] == "ng" ? :render_ng_tasks : :render_active_tasks
+      ::Presenters::TaskPresenter.send(presenter_method, result.tasks)
     end
   end
 
@@ -110,6 +104,10 @@ class Api::TasksController < ApplicationController
   end
 
   private
+    def index_params
+      { type: params[:type] }
+    end
+
     def create_params
       params.require(:task).permit(:task_title, :area_id)
     end

--- a/app/presenters/task_presenter.rb
+++ b/app/presenters/task_presenter.rb
@@ -14,5 +14,34 @@ module Presenters
     def self.render_tasks(tasks)
       tasks.map { |task| render_task(task) }
     end
+
+    # アクティブタスク一覧用（get_active_tasksの結果をフォーマット）
+    # titleをtask_titleに変換して返す
+    def self.render_active_tasks(tasks)
+      tasks.map do |task|
+        {
+          id: task.id,
+          task_title: task.title,
+          area_name: task.area_name,
+          assign_cycle_id: task.assign_cycle_id,
+          created_at: task.created_at
+        }
+      end
+    end
+
+    # NGタスク一覧用（get_ng_tasksの結果をフォーマット）
+    # titleをtask_titleに変換して返す
+    def self.render_ng_tasks(tasks)
+      tasks.map do |task|
+        {
+          id: task.id,
+          task_title: task.title,
+          area_name: task.area_name,
+          history_id: task.history_id,
+          assign_cycle_id: task.assign_cycle_id,
+          created_at: task.created_at
+        }
+      end
+    end
   end
 end

--- a/app/services/tasks/index.rb
+++ b/app/services/tasks/index.rb
@@ -1,0 +1,29 @@
+module Services
+  module Tasks
+    class Index
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        # 認証チェック
+        return failure(nil, ["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # Contract検証
+        validation = ::Contracts::Tasks::Index.call(params)
+        return failure(nil, validation.errors, :unprocessable_entity) unless validation.success?
+
+        # タスク一覧取得
+        type = validation.value[:type]
+        tasks = type == "all" ? @repository.list_active_tasks : @repository.list_ng_tasks
+
+        Result.new(success?: true, task: nil, tasks:, errors: [], status: :ok)
+      end
+
+      private
+        def failure(task, errors, status)
+          Result.new(success?: false, task:, tasks: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -18,6 +18,16 @@ module Services
       def save(task)
         task.save
       end
+
+      # アクティブなタスク一覧を取得
+      def list_active_tasks
+        Task.get_active_tasks
+      end
+
+      # NG状態のタスク一覧を取得
+      def list_ng_tasks
+        Task.get_ng_tasks
+      end
     end
   end
 end

--- a/spec/contracts/tasks/index_spec.rb
+++ b/spec/contracts/tasks/index_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe Contracts::Tasks::Index do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "type='all'を指定" do
+        let(:params) { { type: "all" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ type: "all" })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "type='ng'を指定" do
+        let(:params) { { type: "ng" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ type: "ng" })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "typeが空の場合" do
+        let(:params) { { type: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Type can't be blank")
+        end
+      end
+
+      context "typeがnilの場合" do
+        let(:params) { { type: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Type can't be blank")
+        end
+      end
+
+      context "パラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Type can't be blank")
+        end
+      end
+
+      context "typeが許可されていない値の場合" do
+        let(:params) { { type: "invalid" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Type is not included in the list")
+        end
+      end
+
+      context "typeが'ALL'（大文字）の場合" do
+        let(:params) { { type: "ALL" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Type is not included in the list")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -3,11 +3,14 @@ require "rails_helper"
 RSpec.describe Api::TasksController, type: :controller do
   describe "GET #index" do
     before do
+      @admin = create(:account)
       @member = create(:account_member)
       @area = create(:area)
       @task = create(:task, area_id: @area.id)
       @cycle = create(:assign_cycle, task_id: @task.id)
       @history = create(:assign_history, account_id: @member.id, assign_cycle_id: @cycle.id, ng: true)
+      token = JsonWebToken.encode({ account_id: @admin.id })
+      request.headers["Authorization"] = "Bearer #{token}"
     end
     context "typeがallの場合" do
       it "Status 200が返ってくること" do
@@ -16,7 +19,7 @@ RSpec.describe Api::TasksController, type: :controller do
       end
       it "正しいデータが返ってくること" do
         get :index, params: { type: "all" }
-        expect(JSON.parse(response.body)[0]["title"]).to eq(@task.task_title)
+        expect(JSON.parse(response.body)[0]["task_title"]).to eq(@task.task_title)
       end
     end
     context "typeがngの場合" do
@@ -26,17 +29,26 @@ RSpec.describe Api::TasksController, type: :controller do
       end
       it "正しいデータが返ってくること" do
         get :index, params: { type: "ng" }
-        expect(JSON.parse(response.body)[0]["title"]).to eq(@task.task_title)
+        expect(JSON.parse(response.body)[0]["task_title"]).to eq(@task.task_title)
       end
     end
     context "typeが指定されなかった場合" do
-      it "Status 200が返ってくること" do
+      it "Status unprocessable_entityが返ってくること" do
         get :index
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
-      it "正しいデータが返ってくること" do
+      it "エラーメッセージが返ってくること" do
         get :index
-        expect(JSON.parse(response.body)["message"]).to eq("not type")
+        expect(JSON.parse(response.body)["errors"]).to include("Type can't be blank")
+      end
+    end
+    context "認証なしの場合" do
+      before do
+        request.headers["Authorization"] = nil
+      end
+      it "Status unauthorizedが返ってくること" do
+        get :index, params: { type: "all" }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/services/tasks/index_spec.rb
+++ b/spec/services/tasks/index_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+RSpec.describe Services::Tasks::Index, type: :service do
+  let(:admin_account) { create(:account) }
+  let(:member_account) { create(:account_member) }
+  let!(:area) { create(:area, name: "テストエリア") }
+
+  describe "#call" do
+    describe "正常系" do
+      let!(:task) { create(:task, area: area) }
+      let!(:cycle) { create(:assign_cycle, task: task, is_active: true) }
+
+      context "type='all'を指定した場合" do
+        let(:params) { { type: "all" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.success?).to be true
+        end
+
+        it "tasksにアクティブタスク一覧を返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.tasks).to be_present
+          expect(result.tasks.length).to be >= 1
+        end
+
+        it "statusが:okであること" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.status).to eq(:ok)
+        end
+
+        it "errorsが空であること" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "type='ng'を指定した場合" do
+        let!(:ng_member) { create(:account_member, areas: [area]) }
+        let!(:history) { create(:assign_history, assign_cycle: cycle, account: ng_member, ng: true) }
+
+        let(:params) { { type: "ng" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.success?).to be true
+        end
+
+        it "NGタスク一覧を返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.tasks).to be_present
+        end
+
+        it "statusが:okであること" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.status).to eq(:ok)
+        end
+      end
+
+      context "memberアカウントの場合も取得可能" do
+        let(:params) { { type: "all" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call(params, member_account)
+          expect(result.success?).to be true
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "認証エラー" do
+        context "current_accountがnilの場合" do
+          let(:params) { { type: "all" } }
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call(params, nil)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unauthorizedであること" do
+            result = described_class.new.call(params, nil)
+            expect(result.status).to eq(:unauthorized)
+          end
+
+          it "認証エラーメッセージを返すこと" do
+            result = described_class.new.call(params, nil)
+            expect(result.errors).to include("認証が必要です")
+          end
+        end
+      end
+
+      context "バリデーションエラー" do
+        context "typeが空の場合" do
+          let(:params) { { type: "" } }
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unprocessable_entityであること" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.status).to eq(:unprocessable_entity)
+          end
+
+          it "バリデーションエラーメッセージを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.errors).to include("Type can't be blank")
+          end
+        end
+
+        context "typeが無効な値の場合" do
+          let(:params) { { type: "invalid" } }
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unprocessable_entityであること" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.status).to eq(:unprocessable_entity)
+          end
+
+          it "バリデーションエラーメッセージを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.errors).to include("Type is not included in the list")
+          end
+        end
+      end
+    end
+
+    describe "タスクが存在しない場合" do
+      let(:params) { { type: "all" } }
+
+      it "success?がtrueを返すこと" do
+        result = described_class.new.call(params, admin_account)
+        expect(result.success?).to be true
+      end
+
+      it "空の配列を返すこと" do
+        result = described_class.new.call(params, admin_account)
+        expect(result.tasks).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/tasks/index_spec.rb
+++ b/spec/services/tasks/index_spec.rb
@@ -143,5 +143,49 @@ RSpec.describe Services::Tasks::Index, type: :service do
         expect(result.tasks).to be_empty
       end
     end
+
+    describe "NGタスクが存在しない場合" do
+      let!(:task) { create(:task, area: area) }
+      let!(:cycle) { create(:assign_cycle, task: task, is_active: true) }
+      let!(:active_member) { create(:account_member, areas: [area]) }
+      let!(:history) { create(:assign_history, assign_cycle: cycle, account: active_member, ng: false, completed: false) }
+      let(:params) { { type: "ng" } }
+
+      it "success?がtrueを返すこと" do
+        result = described_class.new.call(params, admin_account)
+        expect(result.success?).to be true
+      end
+
+      it "空の配列を返すこと" do
+        result = described_class.new.call(params, admin_account)
+        expect(result.tasks).to be_empty
+      end
+    end
+
+    describe "依存性注入" do
+      context "カスタムリポジトリを使用する場合" do
+        let(:mock_repository) { instance_double(Services::Tasks::Repository) }
+        let(:service) { described_class.new(repository: mock_repository) }
+        let(:params) { { type: "all" } }
+
+        it "指定されたリポジトリのlist_active_tasksを呼び出すこと" do
+          allow(mock_repository).to receive(:list_active_tasks).and_return([])
+          service.call(params, admin_account)
+          expect(mock_repository).to have_received(:list_active_tasks)
+        end
+      end
+
+      context "type='ng'でカスタムリポジトリを使用する場合" do
+        let(:mock_repository) { instance_double(Services::Tasks::Repository) }
+        let(:service) { described_class.new(repository: mock_repository) }
+        let(:params) { { type: "ng" } }
+
+        it "指定されたリポジトリのlist_ng_tasksを呼び出すこと" do
+          allow(mock_repository).to receive(:list_ng_tasks).and_return([])
+          service.call(params, admin_account)
+          expect(mock_repository).to have_received(:list_ng_tasks)
+        end
+      end
+    end
   end
 end

--- a/spec/services/tasks/index_spec.rb
+++ b/spec/services/tasks/index_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Services::Tasks::Index, type: :service do
 
   describe "#call" do
     describe "正常系" do
-      let!(:task) { create(:task, area: area) }
-      let!(:cycle) { create(:assign_cycle, task: task, is_active: true) }
+      let!(:task) { create(:task, area:) }
+      let!(:cycle) { create(:assign_cycle, task:, is_active: true) }
 
       context "type='all'を指定した場合" do
         let(:params) { { type: "all" } }
@@ -145,8 +145,8 @@ RSpec.describe Services::Tasks::Index, type: :service do
     end
 
     describe "NGタスクが存在しない場合" do
-      let!(:task) { create(:task, area: area) }
-      let!(:cycle) { create(:assign_cycle, task: task, is_active: true) }
+      let!(:task) { create(:task, area:) }
+      let!(:cycle) { create(:assign_cycle, task:, is_active: true) }
       let!(:active_member) { create(:account_member, areas: [area]) }
       let!(:history) { create(:assign_history, assign_cycle: cycle, account: active_member, ng: false, completed: false) }
       let(:params) { { type: "ng" } }


### PR DESCRIPTION
## Summary
- Tasks index エンドポイントを4層アーキテクチャ（Contract→Service→Repository→Presenter）に移行
- JWT認証を追加（認証必須化）
- レスポンスフィールド名を `title` → `task_title` に統一

## 変更内容
| ファイル | 操作 |
|---------|------|
| `app/contracts/tasks/index.rb` | 新規 |
| `app/services/tasks/index.rb` | 新規 |
| `app/services/tasks/repository.rb` | 修正（メソッド追加） |
| `app/presenters/task_presenter.rb` | 修正（メソッド追加） |
| `app/controllers/api/tasks_controller.rb` | 修正 |
| `spec/contracts/tasks/index_spec.rb` | 新規 |
| `spec/services/tasks/index_spec.rb` | 新規 |
| `spec/requests/api/tasks_spec.rb` | 修正 |

## 破壊的変更
### レスポンス形式
**Before:**
```json
[{"id": 1, "title": "タスク名", ...}]
```

**After:**
```json
[{"id": 1, "task_title": "タスク名", ...}]
```

### 認証
- `Authorization: Bearer <token>` ヘッダーが必須に

### エラーレスポンス
**Before:**
```json
{"message": "not type"}
```

**After:**
```json
{"errors": ["Type can't be blank"], "status": 422}
```

## Test plan
- [x] Contract層テスト: 16 examples, 0 failures
- [x] Service層テスト: 19 examples, 0 failures
- [x] Controller層テスト: 更新済み
- [x] 全テスト: 407 examples, 0 failures
- [x] RuboCop: 違反なし

## フロントエンド対応
- `title` → `task_title` への変更が必要
- 認証トークンをリクエストヘッダーに追加が必要