### PR TITLE
refactor: Tasks#show を4層アーキテクチャに移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@
 CLAUDE*
 .claude/
 .serena/
-
-TODO*

--- a/app/contracts/tasks/show.rb
+++ b/app/contracts/tasks/show.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tasks
+    class Show
+      include ActiveModel::Model
+
+      attr_accessor :id
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+
+      def self.call(params)
+        contract = new(id: params[:id])
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { id: id.to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,5 +1,5 @@
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:index, :create]
+  before_action :authenticated?, only: [:index, :show, :create]
 
   def index
     result = ::Services::Tasks::Index.new.call(index_params, @current_account)
@@ -10,9 +10,10 @@ class Api::TasksController < ApplicationController
   end
 
   def show
-    task = Task.find(params[:id])
-
-    render json: task
+    result = ::Services::Tasks::Show.new.call(show_params, @current_account)
+    render_result(result) do
+      ::Presenters::TaskPresenter.render_task(result.task)
+    end
   end
 
   def create
@@ -106,6 +107,10 @@ class Api::TasksController < ApplicationController
   private
     def index_params
       { type: params[:type] }
+    end
+
+    def show_params
+      { id: params[:id] }
     end
 
     def create_params

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -5,6 +5,11 @@ module Services
         Task.new(attrs)
       end
 
+      # IDでタスクを取得
+      def find_by_id(id)
+        Task.find_by(id:)
+      end
+
       # タイトルからエリアを推論
       def infer_area_id(title)
         Area.get_area_id(title)

--- a/app/services/tasks/show.rb
+++ b/app/services/tasks/show.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    class Show
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        # 認証チェック
+        return failure(nil, ["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # Contract検証
+        validation = ::Contracts::Tasks::Show.call(params)
+        return failure(nil, validation.errors, :unprocessable_entity) unless validation.success?
+
+        # タスク取得
+        task = @repository.find_by_id(validation.value[:id])
+        return failure(nil, ["タスクが見つかりません"], :not_found) if task.nil?
+
+        Result.new(success?: true, task:, tasks: nil, errors: [], status: :ok)
+      end
+
+      private
+        def failure(task, errors, status)
+          Result.new(success?: false, task:, tasks: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -1,0 +1,228 @@
+# 4層アーキテクチャ移行 TODO
+
+## アーキテクチャ概要
+
+```
+Controller → Contract → Service → Repository → Model
+                              ↘ Policy
+                              ↘ Domain
+```
+
+各層の役割:
+- **Contract** (`app/contracts/`): 入力検証 + データ変換
+- **Service** (`app/services/`): ユースケース（トランザクション/副作用の統括）
+- **Repository** (`app/services/*/repository.rb`): DBアクセス（Modelへの委譲）
+- **Domain** (`app/domain/`): 純粋な業務ロジック（副作用なし）
+- **Policy** (`app/policies/`): 認可ルール
+- **Presenter** (`app/presenters/`): レスポンス整形
+
+---
+
+## 移行状況サマリー
+
+| コントローラー | 移行済み | 未移行 | 進捗 |
+|--------------|---------|-------|------|
+| Accounts | 6/6 | 0 | ✅ 完了 |
+| Authentications | 1/1 | 0 | ✅ 完了 |
+| Tasks | 3/12 | 9 | 🔶 進行中 |
+| Areas | 0/5 | 5 | ⬜ 未着手 |
+| Comments | 0/5 | 5 | ⬜ 未着手 |
+| Tags | 0/4 | 4 | ⬜ 未着手 |
+| Assigns | 0/1 | 1 | ⬜ 未着手 |
+| AccountAreas | 0/2 | 2 | ⬜ 未着手 |
+| TagAccounts | 0/2 | 2 | ⬜ 未着手 |
+
+**合計: 10/38 (26%)**
+
+---
+
+## Phase 1: Tasks コントローラー完了 (優先度: 高)
+
+### 移行済み ✅
+- [x] `GET /api/tasks` (index) - PR #62
+- [x] `POST /api/tasks` (create) - PR #61
+- [x] `GET /api/tasks/:id` (show)
+  - Contract: `Contracts::Tasks::Show`
+  - Service: `Services::Tasks::Show`
+  - Repository: `find_by_id`追加
+  - Presenter: `TaskPresenter.render_task`（既存）
+  - 認証必須化
+
+### 未移行
+- [ ] `PUT /api/tasks/:id` (update)
+  - Contract: `Contracts::Tasks::Update`
+  - Service: `Services::Tasks::Update`
+  - Repository: `update(task, attrs)`
+  - Presenter: `TaskPresenter.render_task`（既存）
+
+- [ ] `DELETE /api/tasks/:id` (destroy)
+  - Contract: `Contracts::Tasks::Destroy`
+  - Service: `Services::Tasks::Destroy`
+  - Repository: `delete(task)`
+
+- [ ] `POST /api/tasks/:id/tag` (add_tag)
+  - Contract: `Contracts::Tasks::AddTag`
+  - Service: `Services::Tasks::AddTag`
+  - Presenter: `TagPresenter.render_tags`（新規）
+
+- [ ] `DELETE /api/tasks/:id/tag` (remove_tag)
+  - Contract: `Contracts::Tasks::RemoveTag`
+  - Service: `Services::Tasks::RemoveTag`
+
+- [ ] `PUT /api/tasks/:id/completed` (completed)
+  - Contract: `Contracts::Tasks::Completed`
+  - Service: `Services::Tasks::Completed`
+  - Note: AssignHistory操作
+
+- [ ] `PUT /api/tasks/:id/ng` (ng)
+  - Contract: `Contracts::Tasks::Ng`
+  - Service: `Services::Tasks::Ng`
+  - Note: AssignHistory + AssignCycle.assign 呼び出し
+
+- [ ] `POST /api/tasks/:id/newCycle` (create_new_cycle)
+  - Contract: `Contracts::Tasks::CreateNewCycle`
+  - Service: `Services::Tasks::CreateNewCycle`
+  - Note: Task + AssignCycle操作
+
+- [ ] `GET /api/unfulfilled-count` (unfulfilleds_count)
+  - Service: `Services::Tasks::UnfulfilledsCount`
+  - Note: Contractなし（パラメータなし）
+
+- [ ] `GET /api/completed-data` (get_complete_data)
+  - Service: `Services::Tasks::GetCompleteData`
+  - Note: Contractなし（パラメータなし）
+
+- [ ] `GET /api/account/tasks` (get_account_task)
+  - Contract: `Contracts::Tasks::GetAccountTask`
+  - Service: `Services::Tasks::GetAccountTask`
+
+---
+
+## Phase 2: Areas コントローラー (優先度: 中)
+
+- [ ] `GET /api/areas` (index)
+- [ ] `GET /api/areas/:id` (show)
+- [ ] `POST /api/areas` (create)
+- [ ] `PUT /api/areas/:id` (update)
+- [ ] `DELETE /api/areas/:id` (destroy)
+
+必要なファイル:
+- `app/contracts/areas/` - create, show, update, destroy
+- `app/services/areas/` - index, show, create, update, destroy, repository, result
+- `app/presenters/area_presenter.rb`
+
+---
+
+## Phase 3: Comments コントローラー (優先度: 中)
+
+- [ ] `GET /api/comments` (index)
+- [ ] `GET /api/comments/:id` (show)
+- [ ] `POST /api/comments` (create)
+- [ ] `PUT /api/comments/:id` (update)
+- [ ] `DELETE /api/comments/:id` (destroy)
+
+必要なファイル:
+- `app/contracts/comments/`
+- `app/services/comments/`
+- `app/presenters/comment_presenter.rb`
+
+---
+
+## Phase 4: Tags コントローラー (優先度: 低)
+
+- [ ] `GET /api/tags` (index)
+- [ ] `POST /api/tags` (create)
+- [ ] `PUT /api/tags/:id` (update)
+- [ ] `DELETE /api/tags/:id` (destroy)
+
+必要なファイル:
+- `app/contracts/tags/`
+- `app/services/tags/`
+- `app/presenters/tag_presenter.rb`
+
+---
+
+## Phase 5: 中間テーブル操作 (優先度: 低)
+
+### Assigns
+- [ ] `POST /api/tasks/assign/cycle` (cycle_create)
+
+### AccountAreas
+- [ ] `POST /api/account_areas` (create)
+- [ ] `DELETE /api/account_areas/:id` (destroy)
+
+### TagAccounts
+- [ ] `POST /api/tag_accounts` (create)
+- [ ] `DELETE /api/tag_accounts/:id` (destroy)
+
+---
+
+## 移行時の共通チェックリスト
+
+### Contract作成時
+- [ ] ActiveModel::Model を include
+- [ ] 必須バリデーション (presence)
+- [ ] 型バリデーション (inclusion, format)
+- [ ] `self.call(params)` メソッドで Result を返す
+- [ ] テスト: 正常系 + 異常系（空、nil、不正値）
+
+### Service作成時
+- [ ] Repository を DI で受け取る
+- [ ] 認証チェック（必要な場合）
+- [ ] Contract呼び出し
+- [ ] Result オブジェクトで成功/失敗を返す
+- [ ] テスト: 正常系 + 異常系 + DI検証
+
+### Repository追加時
+- [ ] Model への委譲のみ
+- [ ] DB操作ロジックを含めない
+- [ ] テスト: Model呼び出し確認
+
+### Presenter追加/修正時
+- [ ] フィールド名の統一（task_title等）
+- [ ] 不要なフィールドを含めない
+- [ ] テスト: 出力形式の確認
+
+### Controller修正時
+- [ ] `before_action :authenticated?` 追加
+- [ ] `render_result` ブロックで Presenter 呼び出し
+- [ ] private メソッドで params 整形
+- [ ] テスト: HTTPステータス + レスポンス形式
+
+---
+
+## 既知の破壊的変更
+
+| エンドポイント | 変更内容 | 対応PR |
+|--------------|---------|-------|
+| `GET /api/tasks` | 認証必須化、`title` → `task_title` | #62 |
+| `POST /api/tasks` | 認証必須化、レスポンス形式変更 | #61 |
+| `GET /api/tasks/:id` | 認証必須化、Presenter経由レスポンス | - |
+
+---
+
+## 参考: 既存の4層実装例
+
+### Accounts CRUD
+- `app/contracts/accounts/create.rb`
+- `app/services/accounts/create.rb`
+- `app/services/accounts/repository.rb`
+- `app/presenters/account_presenter.rb`
+- `app/policies/account_policy.rb`
+
+### Authentications Login
+- `app/contracts/authentications/login.rb`
+- `app/services/authentications/login.rb`
+
+### Tasks Index/Create
+- `app/contracts/tasks/index.rb`, `create.rb`
+- `app/services/tasks/index.rb`, `create.rb`
+- `app/services/tasks/repository.rb`
+- `app/presenters/task_presenter.rb`
+
+---
+
+## 関連ドキュメント
+
+- `CLAUDE.md`: アーキテクチャ詳細、コーディング規約
+- `ARCHITECTURE.md`: 設計思想（存在する場合）

--- a/spec/contracts/tasks/show_spec.rb
+++ b/spec/contracts/tasks/show_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tasks::Show do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "idが数値文字列の場合" do
+        let(:params) { { id: "1" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ id: 1 })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "idが整数の場合" do
+        let(:params) { { id: 123 } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ id: 123 })
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "idが空文字列の場合" do
+        let(:params) { { id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idがnilの場合" do
+        let(:params) { { id: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "パラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idが非数値の場合" do
+        let(:params) { { id: "abc" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id is not a number")
+        end
+      end
+
+      context "idが0の場合" do
+        let(:params) { { id: "0" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+
+      context "idが負数の場合" do
+        let(:params) { { id: "-1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -148,8 +148,11 @@ RSpec.describe Api::TasksController, type: :controller do
 
   describe "GET #show" do
     before do
+      @admin = create(:account)
       @area = create(:area)
       @task = create(:task, area_id: @area.id)
+      token = JsonWebToken.encode({ account_id: @admin.id })
+      request.headers["Authorization"] = "Bearer #{token}"
     end
 
     context "存在するタスクの場合" do
@@ -164,12 +167,41 @@ RSpec.describe Api::TasksController, type: :controller do
         expect(json_response["id"]).to eq(@task.id)
         expect(json_response["task_title"]).to eq(@task.task_title)
       end
+
+      it "area_nameが返ってくること" do
+        get :show, params: { id: @task.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["area_name"]).to eq(@area.name)
+      end
     end
 
     context "存在しないタスクの場合" do
       it "Status 404が返ってくること" do
         get :show, params: { id: 999999 }
         expect(response).to have_http_status(:not_found)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        get :show, params: { id: 999999 }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("タスクが見つかりません")
+      end
+    end
+
+    context "認証なしの場合" do
+      before do
+        request.headers["Authorization"] = nil
+      end
+
+      it "Status unauthorizedが返ってくること" do
+        get :show, params: { id: @task.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        get :show, params: { id: @task.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("unauthorized")
       end
     end
   end

--- a/spec/services/tasks/show_spec.rb
+++ b/spec/services/tasks/show_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::Show, type: :service do
+  let(:admin_account) { create(:account) }
+  let(:member_account) { create(:account_member) }
+  let!(:area) { create(:area, name: "テストエリア") }
+  let!(:task) { create(:task, area:, task_title: "テストタスク") }
+
+  describe "#call" do
+    describe "正常系" do
+      context "存在するタスクを取得する場合" do
+        let(:params) { { id: task.id.to_s } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.success?).to be true
+        end
+
+        it "taskに該当タスクを返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.task).to eq(task)
+        end
+
+        it "statusが:okであること" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.status).to eq(:ok)
+        end
+
+        it "errorsが空であること" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "memberアカウントでも取得可能" do
+        let(:params) { { id: task.id.to_s } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call(params, member_account)
+          expect(result.success?).to be true
+        end
+
+        it "taskを返すこと" do
+          result = described_class.new.call(params, member_account)
+          expect(result.task).to eq(task)
+        end
+      end
+
+      context "idが整数の場合" do
+        let(:params) { { id: task.id } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.success?).to be true
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "認証エラー" do
+        context "current_accountがnilの場合" do
+          let(:params) { { id: task.id.to_s } }
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call(params, nil)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unauthorizedであること" do
+            result = described_class.new.call(params, nil)
+            expect(result.status).to eq(:unauthorized)
+          end
+
+          it "認証エラーメッセージを返すこと" do
+            result = described_class.new.call(params, nil)
+            expect(result.errors).to include("認証が必要です")
+          end
+        end
+      end
+
+      context "バリデーションエラー" do
+        context "idが空の場合" do
+          let(:params) { { id: "" } }
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unprocessable_entityであること" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.status).to eq(:unprocessable_entity)
+          end
+
+          it "バリデーションエラーメッセージを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.errors).to include("Id can't be blank")
+          end
+        end
+
+        context "idが非数値の場合" do
+          let(:params) { { id: "abc" } }
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unprocessable_entityであること" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.status).to eq(:unprocessable_entity)
+          end
+
+          it "バリデーションエラーメッセージを返すこと" do
+            result = described_class.new.call(params, admin_account)
+            expect(result.errors).to include("Id is not a number")
+          end
+        end
+      end
+
+      context "タスクが存在しない場合" do
+        let(:params) { { id: "999999" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.success?).to be false
+        end
+
+        it "statusが:not_foundであること" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.status).to eq(:not_found)
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.new.call(params, admin_account)
+          expect(result.errors).to include("タスクが見つかりません")
+        end
+      end
+    end
+
+    describe "依存性注入" do
+      context "カスタムリポジトリを使用する場合" do
+        let(:mock_repository) { instance_double(Services::Tasks::Repository) }
+        let(:service) { described_class.new(repository: mock_repository) }
+        let(:params) { { id: "1" } }
+
+        it "指定されたリポジトリのfind_by_idを呼び出すこと" do
+          allow(mock_repository).to receive(:find_by_id).with(1).and_return(task)
+          service.call(params, admin_account)
+          expect(mock_repository).to have_received(:find_by_id).with(1)
+        end
+
+        it "リポジトリがnilを返した場合はnot_foundを返すこと" do
+          allow(mock_repository).to receive(:find_by_id).with(1).and_return(nil)
+          result = service.call(params, admin_account)
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `GET /api/tasks/:id` を4層アーキテクチャに移行
- Contract/Service/Repository パターンに統一
- 認証を必須化

## 変更内容
- `Contracts::Tasks::Show` 新規作成（id検証）
- `Services::Tasks::Show` 新規作成（ユースケース）
- `Repository#find_by_id` 追加
- Controller を Service 呼び出しに変更
- テスト追加（Contract: 17件、Service: 21件、Request: 7件）
- `docs/todo/TODO.md` 追加（進捗管理用）

## 破壊的変更
| 変更 | 内容 |
|------|------|
| 認証必須化 | 未認証リクエストは401エラー |
| レスポンス形式 | Presenter経由（area_name等を含む）|

## Test plan
- [x] Contract テスト 17件 Pass
- [x] Service テスト 21件 Pass
- [x] Request テスト 7件 Pass
- [x] 全テスト 453件 Pass
- [x] RuboCop 違反なし