### PR TITLE
feat: Tasks#add_tag / remove_tag を4層アーキテクチャへ移行

### DIFF
--- a/app/contracts/tasks/add_tag.rb
+++ b/app/contracts/tasks/add_tag.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tasks
+    # タスクへのタグ追加の入力検証
+    class AddTag
+      include ActiveModel::Model
+
+      attr_accessor :task_id, :tag_id
+
+      validates :task_id, presence: true
+      validates :task_id, numericality: { only_integer: true, greater_than: 0 }, if: -> { task_id.present? }
+      validates :tag_id, presence: true
+      validates :tag_id, numericality: { only_integer: true, greater_than: 0 }, if: -> { tag_id.present? }
+
+      def self.call(params)
+        # ルート互換性: :id も :task_id として扱う
+        task_id_value = params[:task_id] || params[:id]
+        contract = new(task_id: task_id_value, tag_id: params[:tag_id])
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { task_id: task_id.to_i, tag_id: tag_id.to_i }
+      end
+    end
+  end
+end

--- a/app/contracts/tasks/remove_tag.rb
+++ b/app/contracts/tasks/remove_tag.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tasks
+    # タスクからのタグ削除の入力検証
+    class RemoveTag
+      include ActiveModel::Model
+
+      attr_accessor :task_id, :tag_id
+
+      validates :task_id, presence: true
+      validates :task_id, numericality: { only_integer: true, greater_than: 0 }, if: -> { task_id.present? }
+      validates :tag_id, presence: true
+      validates :tag_id, numericality: { only_integer: true, greater_than: 0 }, if: -> { tag_id.present? }
+
+      def self.call(params)
+        # ルート互換性: :id も :task_id として扱う
+        task_id_value = params[:task_id] || params[:id]
+        contract = new(task_id: task_id_value, tag_id: params[:tag_id])
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { task_id: task_id.to_i, tag_id: tag_id.to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy]
+  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag]
 
   def index
     result = ::Services::Tasks::Index.new.call(index_params, @current_account)
@@ -40,21 +40,17 @@ class Api::TasksController < ApplicationController
   end
 
   def add_tag
-    task = Task.find(params[:task_id])
-    tag = Tag.find(params[:tag_id])
-
-    task.add_tag(tag)
-
-    render json: task.tags
+    result = ::Services::Tasks::AddTag.new.call(tag_params, @current_account)
+    render_result(result) do
+      ::Presenters::TaskPresenter.render_tags(result.task)
+    end
   end
 
   def remove_tag
-    task = Task.find(params[:task_id])
-    tag = Tag.find(params[:tag_id])
-
-    task.remove_tag(tag)
-
-    render json: task.tags
+    result = ::Services::Tasks::RemoveTag.new.call(tag_params, @current_account)
+    render_result(result) do
+      ::Presenters::TaskPresenter.render_tags(result.task)
+    end
   end
 
   def completed
@@ -126,6 +122,10 @@ class Api::TasksController < ApplicationController
 
     def destroy_params
       { id: params[:id] }
+    end
+
+    def tag_params
+      { task_id: params[:id], tag_id: params[:tag_id] }
     end
 
     def complete_params

--- a/app/presenters/task_presenter.rb
+++ b/app/presenters/task_presenter.rb
@@ -45,5 +45,15 @@ module Presenters
         }
       end
     end
+
+    # タスクに紐付くタグ一覧をフォーマット
+    def self.render_tags(task)
+      task.tags.map do |tag|
+        {
+          id: tag.id,
+          name: tag.name
+        }
+      end
+    end
   end
 end

--- a/app/services/tasks/add_tag.rb
+++ b/app/services/tasks/add_tag.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    # タスクへのタグ追加
+    class AddTag
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # Contract検証
+        validation = ::Contracts::Tasks::AddTag.call(params)
+        return failure(validation.errors, :unprocessable_entity) unless validation.success?
+
+        # 認可チェック（管理者のみ）
+        policy = ::Policies::AccountPolicy.new(current_account)
+        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+
+        value = validation.value
+
+        # タスク取得
+        task = @repository.find_by_id(value[:task_id])
+        return failure(["タスクが見つかりません"], :not_found) if task.nil?
+
+        # タグ取得
+        tag = @repository.find_tag(value[:tag_id])
+        return failure(["タグが見つかりません"], :not_found) if tag.nil?
+
+        # タグ追加（冪等: 既に存在する場合はスキップ）
+        @repository.add_tag(task, tag)
+
+        success(task)
+      end
+
+      private
+        def success(task)
+          Result.new(success?: true, task:, tasks: nil, errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          Result.new(success?: false, task: nil, tasks: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/tasks/add_tag.rb
+++ b/app/services/tasks/add_tag.rb
@@ -31,7 +31,12 @@ module Services
         return failure(["タグが見つかりません"], :not_found) if tag.nil?
 
         # タグ追加（冪等: 既に存在する場合はスキップ）
-        @repository.add_tag(task, tag)
+        added = @repository.add_tag(task, tag)
+        if added
+          Rails.logger.info "Tag added: task_id=#{task.id}, tag_id=#{tag.id}, by_account=#{current_account.id}"
+        else
+          Rails.logger.info "Tag already exists (no-op): task_id=#{task.id}, tag_id=#{tag.id}"
+        end
 
         success(task)
       end

--- a/app/services/tasks/remove_tag.rb
+++ b/app/services/tasks/remove_tag.rb
@@ -31,7 +31,12 @@ module Services
         return failure(["タグが見つかりません"], :not_found) if tag.nil?
 
         # タグ削除（冪等: 存在しない場合はスキップ）
-        @repository.remove_tag(task, tag)
+        removed = @repository.remove_tag(task, tag)
+        if removed
+          Rails.logger.info "Tag removed: task_id=#{task.id}, tag_id=#{tag.id}, by_account=#{current_account.id}"
+        else
+          Rails.logger.info "Tag not associated (no-op): task_id=#{task.id}, tag_id=#{tag.id}"
+        end
 
         success(task)
       end

--- a/app/services/tasks/remove_tag.rb
+++ b/app/services/tasks/remove_tag.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    # タスクからのタグ削除
+    class RemoveTag
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # Contract検証
+        validation = ::Contracts::Tasks::RemoveTag.call(params)
+        return failure(validation.errors, :unprocessable_entity) unless validation.success?
+
+        # 認可チェック（管理者のみ）
+        policy = ::Policies::AccountPolicy.new(current_account)
+        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+
+        value = validation.value
+
+        # タスク取得
+        task = @repository.find_by_id(value[:task_id])
+        return failure(["タスクが見つかりません"], :not_found) if task.nil?
+
+        # タグ取得
+        tag = @repository.find_tag(value[:tag_id])
+        return failure(["タグが見つかりません"], :not_found) if tag.nil?
+
+        # タグ削除（冪等: 存在しない場合はスキップ）
+        @repository.remove_tag(task, tag)
+
+        success(task)
+      end
+
+      private
+        def success(task)
+          Result.new(success?: true, task:, tasks: nil, errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          Result.new(success?: false, task: nil, tasks: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -50,6 +50,27 @@ module Services
       def list_ng_tasks
         Task.get_ng_tasks
       end
+
+      # タグをIDで取得
+      def find_tag(id)
+        Tag.find_by(id:)
+      end
+
+      # タスクにタグを追加
+      def add_tag(task, tag)
+        return false if task.tags.include?(tag)
+
+        task.tags << tag
+        true
+      end
+
+      # タスクからタグを削除
+      def remove_tag(task, tag)
+        return false unless task.tags.include?(tag)
+
+        task.tags.delete(tag)
+        true
+      end
     end
   end
 end

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -24,7 +24,7 @@ Controller → Contract → Service → Repository → Model
 |--------------|---------|-------|------|
 | Accounts | 6/6 | 0 | ✅ 完了 |
 | Authentications | 1/1 | 0 | ✅ 完了 |
-| Tasks | 5/12 | 7 | 🔶 進行中 |
+| Tasks | 7/12 | 5 | 🔶 進行中 |
 | Areas | 0/5 | 5 | ⬜ 未着手 |
 | Comments | 0/5 | 5 | ⬜ 未着手 |
 | Tags | 0/4 | 4 | ⬜ 未着手 |
@@ -32,7 +32,7 @@ Controller → Contract → Service → Repository → Model
 | AccountAreas | 0/2 | 2 | ⬜ 未着手 |
 | TagAccounts | 0/2 | 2 | ⬜ 未着手 |
 
-**合計: 12/38 (32%)**
+**合計: 14/38 (37%)**
 
 ---
 
@@ -60,16 +60,19 @@ Controller → Contract → Service → Repository → Model
   - Repository: `delete(task)`追加
   - 認証必須化、認可追加（admin_only）
 
-### 未移行
-
-- [ ] `POST /api/tasks/:id/tag` (add_tag)
+- [x] `POST /api/tasks/:id/tag` (add_tag)
   - Contract: `Contracts::Tasks::AddTag`
   - Service: `Services::Tasks::AddTag`
-  - Presenter: `TagPresenter.render_tags`（新規）
-
-- [ ] `DELETE /api/tasks/:id/tag` (remove_tag)
+  - Repository: `find_tag`, `add_tag`追加
+  - Presenter: `TaskPresenter.render_tags`（新規）
+  - 認証必須化、認可追加（admin_only）
+- [x] `DELETE /api/tasks/:id/tag` (remove_tag)
   - Contract: `Contracts::Tasks::RemoveTag`
   - Service: `Services::Tasks::RemoveTag`
+  - Repository: `remove_tag`追加
+  - 認証必須化、認可追加（admin_only）
+
+### 未移行
 
 - [ ] `PUT /api/tasks/:id/completed` (completed)
   - Contract: `Contracts::Tasks::Completed`

--- a/spec/contracts/tasks/add_tag_spec.rb
+++ b/spec/contracts/tasks/add_tag_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tasks::AddTag do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "task_idとtag_idが文字列の整数の場合" do
+        let(:params) { { task_id: "1", tag_id: "2" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ task_id: 1, tag_id: 2 })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "task_idとtag_idが整数の場合" do
+        let(:params) { { task_id: 123, tag_id: 456 } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "整数に変換されること" do
+          result = described_class.call(params)
+          expect(result.value[:task_id]).to eq(123)
+          expect(result.value[:tag_id]).to eq(456)
+        end
+      end
+
+      context "idパラメータが使用される場合（ルート互換性）" do
+        let(:params) { { id: "10", tag_id: "20" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "idがtask_idとして扱われること" do
+          result = described_class.call(params)
+          expect(result.value[:task_id]).to eq(10)
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "task_idが空の場合" do
+        let(:params) { { task_id: "", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task can't be blank")
+        end
+      end
+
+      context "task_idがnilの場合" do
+        let(:params) { { task_id: nil, tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "task_idが非数値の場合" do
+        let(:params) { { task_id: "abc", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task is not a number")
+        end
+      end
+
+      context "task_idが0の場合" do
+        let(:params) { { task_id: "0", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task must be greater than 0")
+        end
+      end
+
+      context "task_idが負数の場合" do
+        let(:params) { { task_id: "-1", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "tag_idが空の場合" do
+        let(:params) { { task_id: "1", tag_id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Tag can't be blank")
+        end
+      end
+
+      context "tag_idがnilの場合" do
+        let(:params) { { task_id: "1", tag_id: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "tag_idが非数値の場合" do
+        let(:params) { { task_id: "1", tag_id: "xyz" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Tag is not a number")
+        end
+      end
+
+      context "tag_idが0の場合" do
+        let(:params) { { task_id: "1", tag_id: "0" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "tag_idが負数の場合" do
+        let(:params) { { task_id: "1", tag_id: "-5" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "両方のパラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "複数のエラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task can't be blank")
+          expect(result.errors).to include("Tag can't be blank")
+        end
+      end
+    end
+  end
+
+  describe "#normalized_attributes" do
+    context "文字列の場合" do
+      it "整数に変換されること" do
+        contract = described_class.new(task_id: "42", tag_id: "24")
+        expect(contract.normalized_attributes).to eq({ task_id: 42, tag_id: 24 })
+      end
+    end
+
+    context "整数の場合" do
+      it "そのまま返されること" do
+        contract = described_class.new(task_id: 100, tag_id: 200)
+        expect(contract.normalized_attributes).to eq({ task_id: 100, tag_id: 200 })
+      end
+    end
+  end
+end

--- a/spec/contracts/tasks/remove_tag_spec.rb
+++ b/spec/contracts/tasks/remove_tag_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tasks::RemoveTag do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "task_idとtag_idが文字列の整数の場合" do
+        let(:params) { { task_id: "1", tag_id: "2" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ task_id: 1, tag_id: 2 })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "task_idとtag_idが整数の場合" do
+        let(:params) { { task_id: 123, tag_id: 456 } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "整数に変換されること" do
+          result = described_class.call(params)
+          expect(result.value[:task_id]).to eq(123)
+          expect(result.value[:tag_id]).to eq(456)
+        end
+      end
+
+      context "idパラメータが使用される場合（ルート互換性）" do
+        let(:params) { { id: "10", tag_id: "20" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "idがtask_idとして扱われること" do
+          result = described_class.call(params)
+          expect(result.value[:task_id]).to eq(10)
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "task_idが空の場合" do
+        let(:params) { { task_id: "", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task can't be blank")
+        end
+      end
+
+      context "task_idがnilの場合" do
+        let(:params) { { task_id: nil, tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "task_idが非数値の場合" do
+        let(:params) { { task_id: "abc", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task is not a number")
+        end
+      end
+
+      context "task_idが0の場合" do
+        let(:params) { { task_id: "0", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task must be greater than 0")
+        end
+      end
+
+      context "task_idが負数の場合" do
+        let(:params) { { task_id: "-1", tag_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "tag_idが空の場合" do
+        let(:params) { { task_id: "1", tag_id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Tag can't be blank")
+        end
+      end
+
+      context "tag_idがnilの場合" do
+        let(:params) { { task_id: "1", tag_id: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "tag_idが非数値の場合" do
+        let(:params) { { task_id: "1", tag_id: "xyz" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Tag is not a number")
+        end
+      end
+
+      context "tag_idが0の場合" do
+        let(:params) { { task_id: "1", tag_id: "0" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "tag_idが負数の場合" do
+        let(:params) { { task_id: "1", tag_id: "-5" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "両方のパラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "複数のエラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Task can't be blank")
+          expect(result.errors).to include("Tag can't be blank")
+        end
+      end
+    end
+  end
+
+  describe "#normalized_attributes" do
+    context "文字列の場合" do
+      it "整数に変換されること" do
+        contract = described_class.new(task_id: "42", tag_id: "24")
+        expect(contract.normalized_attributes).to eq({ task_id: 42, tag_id: 24 })
+      end
+    end
+
+    context "整数の場合" do
+      it "そのまま返されること" do
+        contract = described_class.new(task_id: 100, tag_id: 200)
+        expect(contract.normalized_attributes).to eq({ task_id: 100, tag_id: 200 })
+      end
+    end
+  end
+end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -480,6 +480,13 @@ RSpec.describe Api::TasksController, type: :controller do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context "存在しないタグの場合" do
+        it "Status 404が返ってくること" do
+          delete :remove_tag, params: { id: @task.id, tag_id: 999999 }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
     end
 
     context "認証なしの場合" do

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -373,77 +373,135 @@ RSpec.describe Api::TasksController, type: :controller do
 
   describe "POST #add_tag" do
     before do
+      @admin = create(:account, role: "admin")
+      @member = create(:account_member)
       @area = create(:area)
       @task = create(:task, area_id: @area.id)
       @tag = create(:tag, name: "重要")
+      token = JsonWebToken.encode({ account_id: @admin.id })
+      request.headers["Authorization"] = "Bearer #{token}"
     end
 
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        post :add_tag, params: { id: @task.id, task_id: @task.id, tag_id: @tag.id }
-        expect(response).to have_http_status(:ok)
+    context "認証済み管理者の場合" do
+      context "有効なパラメータの場合" do
+        it "Status 200が返ってくること" do
+          post :add_tag, params: { id: @task.id, tag_id: @tag.id }
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "タスクにタグが紐付けられること" do
+          expect {
+            post :add_tag, params: { id: @task.id, tag_id: @tag.id }
+          }.to change { @task.tags.count }.by(1)
+        end
+
+        it "紐付けられたタグ一覧が返ってくること" do
+          post :add_tag, params: { id: @task.id, tag_id: @tag.id }
+          json_response = JSON.parse(response.body)
+          expect(json_response.length).to eq(1)
+          expect(json_response[0]["name"]).to eq("重要")
+        end
       end
 
-      it "タスクにタグが紐付けられること" do
-        expect {
-          post :add_tag, params: { id: @task.id, task_id: @task.id, tag_id: @tag.id }
-        }.to change { @task.tags.count }.by(1)
+      context "存在しないタスクの場合" do
+        it "Status 404が返ってくること" do
+          post :add_tag, params: { id: 999999, tag_id: @tag.id }
+          expect(response).to have_http_status(:not_found)
+        end
       end
 
-      it "紐付けられたタグ一覧が返ってくること" do
-        post :add_tag, params: { id: @task.id, task_id: @task.id, tag_id: @tag.id }
-        json_response = JSON.parse(response.body)
-        expect(json_response.length).to eq(1)
-        expect(json_response[0]["name"]).to eq("重要")
+      context "存在しないタグの場合" do
+        it "Status 404が返ってくること" do
+          post :add_tag, params: { id: @task.id, tag_id: 999999 }
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
 
-    context "存在しないタスクの場合" do
-      it "Status 404が返ってくること" do
-        post :add_tag, params: { id: 999999, task_id: 999999, tag_id: @tag.id }
-        expect(response).to have_http_status(:not_found)
+    context "認証なしの場合" do
+      before do
+        request.headers["Authorization"] = nil
+      end
+
+      it "Status 401が返ってくること" do
+        post :add_tag, params: { id: @task.id, tag_id: @tag.id }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    context "存在しないタグの場合" do
-      it "Status 404が返ってくること" do
-        post :add_tag, params: { id: @task.id, task_id: @task.id, tag_id: 999999 }
-        expect(response).to have_http_status(:not_found)
+    context "memberユーザーの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 403が返ってくること" do
+        post :add_tag, params: { id: @task.id, tag_id: @tag.id }
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
 
   describe "DELETE #remove_tag" do
     before do
+      @admin = create(:account, role: "admin")
+      @member = create(:account_member)
       @area = create(:area)
       @task = create(:task, area_id: @area.id)
       @tag = create(:tag, name: "重要")
       @task.add_tag(@tag)
+      token = JsonWebToken.encode({ account_id: @admin.id })
+      request.headers["Authorization"] = "Bearer #{token}"
     end
 
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        delete :remove_tag, params: { id: @task.id, task_id: @task.id, tag_id: @tag.id }
-        expect(response).to have_http_status(:ok)
+    context "認証済み管理者の場合" do
+      context "有効なパラメータの場合" do
+        it "Status 200が返ってくること" do
+          delete :remove_tag, params: { id: @task.id, tag_id: @tag.id }
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "タスクからタグが削除されること" do
+          expect {
+            delete :remove_tag, params: { id: @task.id, tag_id: @tag.id }
+          }.to change { @task.tags.count }.by(-1)
+        end
+
+        it "残りのタグ一覧が返ってくること" do
+          delete :remove_tag, params: { id: @task.id, tag_id: @tag.id }
+          json_response = JSON.parse(response.body)
+          expect(json_response.length).to eq(0)
+        end
       end
 
-      it "タスクからタグが削除されること" do
-        expect {
-          delete :remove_tag, params: { id: @task.id, task_id: @task.id, tag_id: @tag.id }
-        }.to change { @task.tags.count }.by(-1)
-      end
-
-      it "残りのタグ一覧が返ってくること" do
-        delete :remove_tag, params: { id: @task.id, task_id: @task.id, tag_id: @tag.id }
-        json_response = JSON.parse(response.body)
-        expect(json_response.length).to eq(0)
+      context "存在しないタスクの場合" do
+        it "Status 404が返ってくること" do
+          delete :remove_tag, params: { id: 999999, tag_id: @tag.id }
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
 
-    context "存在しないタスクの場合" do
-      it "Status 404が返ってくること" do
-        delete :remove_tag, params: { id: 999999, task_id: 999999, tag_id: @tag.id }
-        expect(response).to have_http_status(:not_found)
+    context "認証なしの場合" do
+      before do
+        request.headers["Authorization"] = nil
+      end
+
+      it "Status 401が返ってくること" do
+        delete :remove_tag, params: { id: @task.id, tag_id: @tag.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "memberユーザーの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 403が返ってくること" do
+        delete :remove_tag, params: { id: @task.id, tag_id: @tag.id }
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/spec/services/tasks/add_tag_spec.rb
+++ b/spec/services/tasks/add_tag_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::AddTag, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:area) { create(:area) }
+    let!(:target_task) { create(:task, area:) }
+    let!(:tag) { create(:tag, name: "重要") }
+
+    let(:valid_params) do
+      { task_id: target_task.id, tag_id: tag.id }
+    end
+
+    describe "正常系" do
+      context "adminユーザーがタグを追加する場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "タスクにタグが追加されること" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.to change { target_task.tags.count }.by(1)
+        end
+
+        it "追加したタスクを返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.task).to eq(target_task)
+          expect(result.task.tags).to include(tag)
+        end
+      end
+
+      context "idパラメータを使用する場合（ルート互換性）" do
+        it "成功を返すこと" do
+          params = { id: target_task.id, tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be true
+        end
+      end
+
+      context "既にタグが追加されている場合" do
+        before { target_task.tags << tag }
+
+        it "成功を返すこと（冪等性）" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+        end
+
+        it "タグの数が増えないこと" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.not_to change { target_task.tags.count }
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "認証エラーの場合" do
+        context "current_accountがnilの場合" do
+          it "unauthorizedを返すこと" do
+            result = described_class.new.call(valid_params, nil)
+
+            expect(result.success?).to be false
+            expect(result.status).to eq(:unauthorized)
+            expect(result.errors).to include("認証が必要です")
+          end
+
+          it "タグが追加されないこと" do
+            expect {
+              described_class.new.call(valid_params, nil)
+            }.not_to change { target_task.tags.count }
+          end
+        end
+      end
+
+      context "バリデーションエラーの場合" do
+        it "task_idが空の場合、失敗を返すこと" do
+          params = { task_id: nil, tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+          expect(result.errors).not_to be_empty
+        end
+
+        it "tag_idが空の場合、失敗を返すこと" do
+          params = { task_id: target_task.id, tag_id: nil }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "task_idが数値でない場合、失敗を返すこと" do
+          params = { task_id: "abc", tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "タグが追加されないこと" do
+          params = { task_id: nil, tag_id: tag.id }
+          expect {
+            described_class.new.call(params, admin)
+          }.not_to change { target_task.tags.count }
+        end
+      end
+
+      context "権限エラーの場合" do
+        context "memberユーザーの場合" do
+          it "forbiddenを返すこと" do
+            result = described_class.new.call(valid_params, member)
+
+            expect(result.success?).to be false
+            expect(result.status).to eq(:forbidden)
+            expect(result.errors).to include("権限がありません")
+          end
+
+          it "タグが追加されないこと" do
+            expect {
+              described_class.new.call(valid_params, member)
+            }.not_to change { target_task.tags.count }
+          end
+        end
+      end
+
+      context "タスクが存在しない場合" do
+        it "not_foundを返すこと" do
+          params = { task_id: 999999, tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors).to include("タスクが見つかりません")
+        end
+      end
+
+      context "タグが存在しない場合" do
+        it "not_foundを返すこと" do
+          params = { task_id: target_task.id, tag_id: 999999 }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors).to include("タグが見つかりません")
+        end
+      end
+    end
+
+    describe "処理順序の検証" do
+      it "認証 → バリデーション → 認可 → タスク検索 → タグ検索 → 追加の順序で処理されること" do
+        # 認証エラーはバリデーション前に返される
+        result_unauth = described_class.new.call({ task_id: nil, tag_id: nil }, nil)
+        expect(result_unauth.status).to eq(:unauthorized)
+
+        # バリデーションエラーは認可チェック前に返される
+        result_invalid = described_class.new.call({ task_id: nil, tag_id: nil }, admin)
+        expect(result_invalid.status).to eq(:unprocessable_entity)
+
+        # 認可エラーは存在チェック前に返される（存在しないIDでも403）
+        result_forbidden = described_class.new.call({ task_id: 999999, tag_id: 999999 }, member)
+        expect(result_forbidden.status).to eq(:forbidden)
+
+        # タスクが存在しない場合はnot_foundを返す
+        result_task_not_found = described_class.new.call({ task_id: 999999, tag_id: tag.id }, admin)
+        expect(result_task_not_found.status).to eq(:not_found)
+        expect(result_task_not_found.errors).to include("タスクが見つかりません")
+
+        # タグが存在しない場合はnot_foundを返す
+        result_tag_not_found = described_class.new.call({ task_id: target_task.id, tag_id: 999999 }, admin)
+        expect(result_tag_not_found.status).to eq(:not_found)
+        expect(result_tag_not_found.errors).to include("タグが見つかりません")
+      end
+    end
+
+    describe "Repository DI" do
+      it "カスタムRepositoryを受け取れること" do
+        mock_repository = instance_double(Services::Tasks::Repository)
+        allow(mock_repository).to receive(:find_by_id).with(target_task.id).and_return(target_task)
+        allow(mock_repository).to receive(:find_tag).with(tag.id).and_return(tag)
+        allow(mock_repository).to receive(:add_tag).with(target_task, tag).and_return(true)
+
+        service = described_class.new(repository: mock_repository)
+        result = service.call(valid_params, admin)
+
+        expect(result.success?).to be true
+        expect(mock_repository).to have_received(:find_by_id).with(target_task.id)
+        expect(mock_repository).to have_received(:find_tag).with(tag.id)
+        expect(mock_repository).to have_received(:add_tag).with(target_task, tag)
+      end
+    end
+  end
+end

--- a/spec/services/tasks/remove_tag_spec.rb
+++ b/spec/services/tasks/remove_tag_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::RemoveTag, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:area) { create(:area) }
+    let!(:target_task) { create(:task, area:) }
+    let!(:tag) { create(:tag, name: "重要") }
+
+    let(:valid_params) do
+      { task_id: target_task.id, tag_id: tag.id }
+    end
+
+    describe "正常系" do
+      before { target_task.tags << tag }
+
+      context "adminユーザーがタグを削除する場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "タスクからタグが削除されること" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.to change { target_task.tags.count }.by(-1)
+        end
+
+        it "更新されたタスクを返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.task).to eq(target_task)
+          expect(result.task.tags).not_to include(tag)
+        end
+      end
+
+      context "idパラメータを使用する場合（ルート互換性）" do
+        it "成功を返すこと" do
+          params = { id: target_task.id, tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be true
+        end
+      end
+    end
+
+    describe "正常系（タグが追加されていない場合）" do
+      context "タグが追加されていない場合" do
+        it "成功を返すこと（冪等性）" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+        end
+
+        it "タグの数が変わらないこと" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.not_to change { target_task.tags.count }
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "認証エラーの場合" do
+        context "current_accountがnilの場合" do
+          it "unauthorizedを返すこと" do
+            result = described_class.new.call(valid_params, nil)
+
+            expect(result.success?).to be false
+            expect(result.status).to eq(:unauthorized)
+            expect(result.errors).to include("認証が必要です")
+          end
+
+          it "タグが削除されないこと" do
+            target_task.tags << tag
+            expect {
+              described_class.new.call(valid_params, nil)
+            }.not_to change { target_task.tags.count }
+          end
+        end
+      end
+
+      context "バリデーションエラーの場合" do
+        it "task_idが空の場合、失敗を返すこと" do
+          params = { task_id: nil, tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+          expect(result.errors).not_to be_empty
+        end
+
+        it "tag_idが空の場合、失敗を返すこと" do
+          params = { task_id: target_task.id, tag_id: nil }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "task_idが数値でない場合、失敗を返すこと" do
+          params = { task_id: "abc", tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "タグが削除されないこと" do
+          target_task.tags << tag
+          params = { task_id: nil, tag_id: tag.id }
+          expect {
+            described_class.new.call(params, admin)
+          }.not_to change { target_task.tags.count }
+        end
+      end
+
+      context "権限エラーの場合" do
+        context "memberユーザーの場合" do
+          it "forbiddenを返すこと" do
+            result = described_class.new.call(valid_params, member)
+
+            expect(result.success?).to be false
+            expect(result.status).to eq(:forbidden)
+            expect(result.errors).to include("権限がありません")
+          end
+
+          it "タグが削除されないこと" do
+            target_task.tags << tag
+            expect {
+              described_class.new.call(valid_params, member)
+            }.not_to change { target_task.tags.count }
+          end
+        end
+      end
+
+      context "タスクが存在しない場合" do
+        it "not_foundを返すこと" do
+          params = { task_id: 999999, tag_id: tag.id }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors).to include("タスクが見つかりません")
+        end
+      end
+
+      context "タグが存在しない場合" do
+        it "not_foundを返すこと" do
+          params = { task_id: target_task.id, tag_id: 999999 }
+          result = described_class.new.call(params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors).to include("タグが見つかりません")
+        end
+      end
+    end
+
+    describe "処理順序の検証" do
+      it "認証 → バリデーション → 認可 → タスク検索 → タグ検索 → 削除の順序で処理されること" do
+        # 認証エラーはバリデーション前に返される
+        result_unauth = described_class.new.call({ task_id: nil, tag_id: nil }, nil)
+        expect(result_unauth.status).to eq(:unauthorized)
+
+        # バリデーションエラーは認可チェック前に返される
+        result_invalid = described_class.new.call({ task_id: nil, tag_id: nil }, admin)
+        expect(result_invalid.status).to eq(:unprocessable_entity)
+
+        # 認可エラーは存在チェック前に返される（存在しないIDでも403）
+        result_forbidden = described_class.new.call({ task_id: 999999, tag_id: 999999 }, member)
+        expect(result_forbidden.status).to eq(:forbidden)
+
+        # タスクが存在しない場合はnot_foundを返す
+        result_task_not_found = described_class.new.call({ task_id: 999999, tag_id: tag.id }, admin)
+        expect(result_task_not_found.status).to eq(:not_found)
+        expect(result_task_not_found.errors).to include("タスクが見つかりません")
+
+        # タグが存在しない場合はnot_foundを返す
+        result_tag_not_found = described_class.new.call({ task_id: target_task.id, tag_id: 999999 }, admin)
+        expect(result_tag_not_found.status).to eq(:not_found)
+        expect(result_tag_not_found.errors).to include("タグが見つかりません")
+      end
+    end
+
+    describe "Repository DI" do
+      before { target_task.tags << tag }
+
+      it "カスタムRepositoryを受け取れること" do
+        mock_repository = instance_double(Services::Tasks::Repository)
+        allow(mock_repository).to receive(:find_by_id).with(target_task.id).and_return(target_task)
+        allow(mock_repository).to receive(:find_tag).with(tag.id).and_return(tag)
+        allow(mock_repository).to receive(:remove_tag).with(target_task, tag).and_return(true)
+
+        service = described_class.new(repository: mock_repository)
+        result = service.call(valid_params, admin)
+
+        expect(result.success?).to be true
+        expect(mock_repository).to have_received(:find_by_id).with(target_task.id)
+        expect(mock_repository).to have_received(:find_tag).with(tag.id)
+        expect(mock_repository).to have_received(:remove_tag).with(target_task, tag)
+      end
+    end
+  end
+end

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -178,4 +178,98 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       expect(Task).to have_received(:get_ng_tasks)
     end
   end
+
+  describe "#find_tag" do
+    let!(:tag) { create(:tag) }
+
+    context "存在するIDの場合" do
+      it "タグを返すこと" do
+        result = repository.find_tag(tag.id)
+        expect(result).to eq(tag)
+      end
+    end
+
+    context "存在しないIDの場合" do
+      it "nilを返すこと" do
+        result = repository.find_tag(999999)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#add_tag" do
+    let!(:task) { create(:task, area:) }
+    let!(:tag) { create(:tag) }
+
+    context "タグが未追加の場合" do
+      it "trueを返すこと" do
+        result = repository.add_tag(task, tag)
+        expect(result).to be true
+      end
+
+      it "タスクにタグが追加されること" do
+        repository.add_tag(task, tag)
+        expect(task.tags).to include(tag)
+      end
+
+      it "TagTaskレコードが作成されること" do
+        expect {
+          repository.add_tag(task, tag)
+        }.to change(TagTask, :count).by(1)
+      end
+    end
+
+    context "タグが既に追加されている場合" do
+      before { task.tags << tag }
+
+      it "falseを返すこと" do
+        result = repository.add_tag(task, tag)
+        expect(result).to be false
+      end
+
+      it "TagTaskレコードが増えないこと" do
+        expect {
+          repository.add_tag(task, tag)
+        }.not_to change(TagTask, :count)
+      end
+    end
+  end
+
+  describe "#remove_tag" do
+    let!(:task) { create(:task, area:) }
+    let!(:tag) { create(:tag) }
+
+    context "タグが追加されている場合" do
+      before { task.tags << tag }
+
+      it "trueを返すこと" do
+        result = repository.remove_tag(task, tag)
+        expect(result).to be true
+      end
+
+      it "タスクからタグが削除されること" do
+        repository.remove_tag(task, tag)
+        expect(task.tags).not_to include(tag)
+      end
+
+      it "TagTaskレコードが削除されること" do
+        expect {
+          repository.remove_tag(task, tag)
+        }.to change(TagTask, :count).by(-1)
+      end
+    end
+
+    context "タグが追加されていない場合" do
+      it "falseを返すこと" do
+        result = repository.remove_tag(task, tag)
+        expect(result).to be false
+      end
+
+      it "TagTaskレコードが変わらないこと" do
+        expect {
+          repository.remove_tag(task, tag)
+        }.not_to change(TagTask, :count)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Tasks#add_tag および remove_tag エンドポイントを4層アーキテクチャ（Controller → Contract → Service → Repository）へ移行
- 認証必須化と認可追加（admin_only）により、セキュリティを強化
- TDDアプローチで全テストを先に作成してから実装

## 変更内容

### 新規ファイル（8ファイル）
- `app/contracts/tasks/add_tag.rb` - 入力検証（task_id, tag_id）
- `app/contracts/tasks/remove_tag.rb` - 入力検証
- `app/services/tasks/add_tag.rb` - タグ追加ユースケース
- `app/services/tasks/remove_tag.rb` - タグ削除ユースケース
- `spec/contracts/tasks/add_tag_spec.rb` - 26テスト
- `spec/contracts/tasks/remove_tag_spec.rb` - 26テスト
- `spec/services/tasks/add_tag_spec.rb` - 18テスト
- `spec/services/tasks/remove_tag_spec.rb` - 18テスト

### 修正ファイル（6ファイル）
- `app/services/tasks/repository.rb` - find_tag, add_tag, remove_tag メソッド追加
- `app/presenters/task_presenter.rb` - render_tags メソッド追加
- `app/controllers/api/tasks_controller.rb` - Service経由に変更、before_action追加
- `spec/services/tasks/repository_spec.rb` - 12テスト追加
- `spec/requests/api/tasks_spec.rb` - 認証・認可テスト追加
- `docs/todo/TODO.md` - 進捗更新（32% → 37%）

## 破壊的変更

| エンドポイント | 変更内容 |
|--------------|---------|
| POST /api/tasks/:id/tag | 認証必須化、認可追加（admin_only） |
| DELETE /api/tasks/:id/tag | 認証必須化、認可追加（admin_only） |

**影響**: メンバー権限のユーザーはタグ操作が不可になります

## 修正した問題

1. **認証なし** → 認証必須化
2. **認可なし** → admin_only ポリシー追加
3. **パラメータ不整合**（ルート`:id` vs コード`task_id`）→ Contract で吸収
4. **4層アーキテクチャ違反** → Service/Repository/Presenter 経由に変更

## Test plan

- [x] Contract テスト: 52 examples (AddTag: 26, RemoveTag: 26)
- [x] Repository テスト: 30 examples (12 新規追加)
- [x] Service テスト: 36 examples (AddTag: 18, RemoveTag: 18)
- [x] Request テスト: 69 examples (認証・認可テスト追加)
- [x] 全テスト: 711 examples, 0 failures
- [x] RuboCop: 153 files, no offenses