### PR TITLE
feat: Tasks#completed を4層アーキテクチャへ移行

### DIFF
--- a/app/contracts/tasks/completed.rb
+++ b/app/contracts/tasks/completed.rb
@@ -3,7 +3,7 @@
 module Contracts
   module Tasks
     # タスク完了の入力検証
-    # Note: idはAssignHistoryのID
+    # Note: idはAssignHistoryのID（APIパス /tasks/:id/completed の :id は歴史的経緯による命名）
     class Completed
       include ActiveModel::Model
 

--- a/app/contracts/tasks/completed.rb
+++ b/app/contracts/tasks/completed.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tasks
+    # タスク完了の入力検証
+    # Note: idはAssignHistoryのID
+    class Completed
+      include ActiveModel::Model
+
+      attr_accessor :id
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+
+      def self.call(params)
+        contract = new(id: params[:id])
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { id: id.to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag]
+  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed]
 
   def index
     result = ::Services::Tasks::Index.new.call(index_params, @current_account)
@@ -54,14 +54,11 @@ class Api::TasksController < ApplicationController
   end
 
   def completed
-    assign_history = AssignHistory.find(params[:id])
-    assign_history.change_completed
-
-    # if assign_history.completed
-    if assign_history.completed
-      render json: { message: "change completed", result: true }
+    result = ::Services::Tasks::Completed.new.call(completed_params, @current_account)
+    if result.success?
+      render json: { message: result.message, result: true }, status: result.status
     else
-      render json: { message: "change failed", result: false }
+      render json: { message: "change failed", result: false, errors: result.errors }, status: result.status
     end
   end
 
@@ -126,6 +123,10 @@ class Api::TasksController < ApplicationController
 
     def tag_params
       { task_id: params[:id], tag_id: params[:tag_id] }
+    end
+
+    def completed_params
+      { id: params[:id] }
     end
 
     def complete_params

--- a/app/services/tasks/completed.rb
+++ b/app/services/tasks/completed.rb
@@ -25,7 +25,7 @@ module Services
           # 関連するTaskを取得
           task = assign_history.assign_cycle.task
 
-          # 認可チェック（管理者 または タスク担当者）
+          # 認可チェック（管理者 または 現在のアクティブな担当者のみ）
           unless can_complete?(current_account, task)
             return failure(["権限がありません"], :forbidden)
           end
@@ -35,7 +35,7 @@ module Services
             return failure(["既に完了しています"], :unprocessable_entity)
           end
 
-          # 完了処理実行
+          # 完了処理実行: AssignHistory完了 + AssignCycle非アクティブ化（トランザクション内で実行）
           @repository.complete_assign_history(assign_history)
           @repository.deactivate_cycle(assign_history.assign_cycle)
 

--- a/app/services/tasks/completed.rb
+++ b/app/services/tasks/completed.rb
@@ -45,6 +45,9 @@ module Services
       rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
         Rails.logger.error "Task complete lock error: id=#{params[:id]}, error=#{e.message}"
         failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error "Task complete save error: id=#{params[:id]}, error=#{e.message}"
+        failure(["タスクの完了処理に失敗しました。"], :unprocessable_entity)
       end
 
       private

--- a/app/services/tasks/completed.rb
+++ b/app/services/tasks/completed.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    # タスク完了処理
+    class Completed
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # Contract検証
+        validation = ::Contracts::Tasks::Completed.call(params)
+        return failure(validation.errors, :unprocessable_entity) unless validation.success?
+
+        # トランザクション内で処理
+        AssignHistory.transaction do
+          # AssignHistory取得（悲観的ロック）
+          assign_history = @repository.find_assign_history_with_lock(validation.value[:id])
+          return failure(["担当履歴が見つかりません"], :not_found) if assign_history.nil?
+
+          # 関連するTaskを取得
+          task = assign_history.assign_cycle.task
+
+          # 認可チェック（管理者 または タスク担当者）
+          unless can_complete?(current_account, task)
+            return failure(["権限がありません"], :forbidden)
+          end
+
+          # 既に完了済みチェック
+          if assign_history.completed?
+            return failure(["既に完了しています"], :unprocessable_entity)
+          end
+
+          # 完了処理実行
+          @repository.complete_assign_history(assign_history)
+          @repository.deactivate_cycle(assign_history.assign_cycle)
+
+          Rails.logger.info "Task completed: assign_history_id=#{assign_history.id}, task_id=#{task.id}, by_account=#{current_account.id}"
+          success
+        end
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Task complete lock error: id=#{params[:id]}, error=#{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
+      end
+
+      private
+        def can_complete?(account, task)
+          policy = ::Policies::AccountPolicy.new(account)
+          return true if policy.admin_only?
+
+          task.current_assignee?(account)
+        end
+
+        def success
+          CompletedResult.new(success?: true, message: "change completed", errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          CompletedResult.new(success?: false, message: "change failed", errors:, status:)
+        end
+    end
+
+    # Completed専用Result（後方互換性のためmessageを返す）
+    CompletedResult = Struct.new(:success?, :message, :errors, :status, keyword_init: true)
+  end
+end

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -77,7 +77,7 @@ module Services
         AssignHistory.lock.find_by(id:)
       end
 
-      # AssignHistoryの完了処理
+      # AssignHistoryの完了処理（Service層からの呼び出し用）
       # @raise [ActiveRecord::RecordInvalid] バリデーション失敗時
       def complete_assign_history(assign_history)
         assign_history.update!(completed: true, completed_at: Time.current)

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -71,6 +71,21 @@ module Services
         task.tags.delete(tag)
         true
       end
+
+      # AssignHistoryをIDで取得（悲観的ロック付き）
+      def find_assign_history_with_lock(id)
+        AssignHistory.lock.find_by(id:)
+      end
+
+      # AssignHistoryの完了処理
+      def complete_assign_history(assign_history)
+        assign_history.update(completed: true, completed_at: Time.current)
+      end
+
+      # AssignCycleの非アクティブ化
+      def deactivate_cycle(cycle)
+        cycle.update(is_active: false)
+      end
     end
   end
 end

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -72,19 +72,21 @@ module Services
         true
       end
 
-      # AssignHistoryをIDで取得（悲観的ロック付き）
+      # AssignHistoryをIDで取得（悲観的ロック付き - 同時完了操作によるレースコンディション防止）
       def find_assign_history_with_lock(id)
         AssignHistory.lock.find_by(id:)
       end
 
       # AssignHistoryの完了処理
+      # @raise [ActiveRecord::RecordInvalid] バリデーション失敗時
       def complete_assign_history(assign_history)
-        assign_history.update(completed: true, completed_at: Time.current)
+        assign_history.update!(completed: true, completed_at: Time.current)
       end
 
       # AssignCycleの非アクティブ化
+      # @raise [ActiveRecord::RecordInvalid] バリデーション失敗時
       def deactivate_cycle(cycle)
-        cycle.update(is_active: false)
+        cycle.update!(is_active: false)
       end
     end
   end

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -24,7 +24,7 @@ Controller → Contract → Service → Repository → Model
 |--------------|---------|-------|------|
 | Accounts | 6/6 | 0 | ✅ 完了 |
 | Authentications | 1/1 | 0 | ✅ 完了 |
-| Tasks | 7/12 | 5 | 🔶 進行中 |
+| Tasks | 8/12 | 4 | 🔶 進行中 |
 | Areas | 0/5 | 5 | ⬜ 未着手 |
 | Comments | 0/5 | 5 | ⬜ 未着手 |
 | Tags | 0/4 | 4 | ⬜ 未着手 |
@@ -32,7 +32,7 @@ Controller → Contract → Service → Repository → Model
 | AccountAreas | 0/2 | 2 | ⬜ 未着手 |
 | TagAccounts | 0/2 | 2 | ⬜ 未着手 |
 
-**合計: 14/38 (37%)**
+**合計: 15/38 (39%)**
 
 ---
 
@@ -71,13 +71,13 @@ Controller → Contract → Service → Repository → Model
   - Service: `Services::Tasks::RemoveTag`
   - Repository: `remove_tag`追加
   - 認証必須化、認可追加（admin_only）
-
-### 未移行
-
-- [ ] `PUT /api/tasks/:id/completed` (completed)
+- [x] `PUT /api/tasks/:id/completed` (completed)
   - Contract: `Contracts::Tasks::Completed`
   - Service: `Services::Tasks::Completed`
-  - Note: AssignHistory操作
+  - Repository: `find_assign_history_with_lock`, `complete_assign_history`, `deactivate_cycle`追加
+  - 認証必須化、認可追加（admin + 担当者）
+
+### 未移行
 
 - [ ] `PUT /api/tasks/:id/ng` (ng)
   - Contract: `Contracts::Tasks::Ng`

--- a/spec/contracts/tasks/completed_spec.rb
+++ b/spec/contracts/tasks/completed_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tasks::Completed do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "idが文字列の整数の場合" do
+        let(:params) { { id: "1" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ id: 1 })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "idが整数の場合" do
+        let(:params) { { id: 123 } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "idが整数に変換されること" do
+          result = described_class.call(params)
+          expect(result.value[:id]).to eq(123)
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "idが空文字列の場合" do
+        let(:params) { { id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idがnilの場合" do
+        let(:params) { { id: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "パラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idが非数値の場合" do
+        let(:params) { { id: "abc" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id is not a number")
+        end
+      end
+
+      context "idが0の場合" do
+        let(:params) { { id: "0" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+
+      context "idが負数の場合" do
+        let(:params) { { id: "-1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+
+      context "idが小数の場合" do
+        let(:params) { { id: "1.5" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be an integer")
+        end
+      end
+    end
+  end
+
+  describe "#normalized_attributes" do
+    context "文字列のidの場合" do
+      it "idが整数に変換されること" do
+        contract = described_class.new(id: "42")
+        expect(contract.normalized_attributes).to eq({ id: 42 })
+      end
+    end
+
+    context "整数のidの場合" do
+      it "idがそのまま返されること" do
+        contract = described_class.new(id: 100)
+        expect(contract.normalized_attributes).to eq({ id: 100 })
+      end
+    end
+  end
+end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -515,14 +515,28 @@ RSpec.describe Api::TasksController, type: :controller do
 
   describe "PUT #completed" do
     before do
+      @admin = create(:account)
       @member = create(:account_member)
+      @other_member = create(:account_member)
       @area = create(:area)
       @task = create(:task, area_id: @area.id)
-      @cycle = create(:assign_cycle, task_id: @task.id)
-      @history = create(:assign_history, account_id: @member.id, assign_cycle_id: @cycle.id, completed: false)
+      @cycle = create(:assign_cycle, task_id: @task.id, is_active: true)
+      @history = create(:assign_history, account_id: @member.id, assign_cycle_id: @cycle.id, completed: false, ng: false)
     end
 
-    context "有効なパラメータの場合" do
+    context "認証なしの場合" do
+      it "Status 401が返ってくること" do
+        put :completed, params: { id: @history.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "管理者が完了する場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
       it "Status 200が返ってくること" do
         put :completed, params: { id: @history.id }
         expect(response).to have_http_status(:ok)
@@ -533,12 +547,98 @@ RSpec.describe Api::TasksController, type: :controller do
         json_response = JSON.parse(response.body)
         expect(json_response["result"]).to be true
       end
+
+      it "正しいメッセージが返ってくること" do
+        put :completed, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["message"]).to eq("change completed")
+      end
+
+      it "AssignHistoryのcompletedがtrueに更新されること" do
+        put :completed, params: { id: @history.id }
+        expect(@history.reload.completed).to be true
+      end
+
+      it "AssignCycleのis_activeがfalseに更新されること" do
+        put :completed, params: { id: @history.id }
+        expect(@cycle.reload.is_active).to be false
+      end
+    end
+
+    context "担当メンバーが自分のタスクを完了する場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 200が返ってくること" do
+        put :completed, params: { id: @history.id }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "AssignHistoryのcompletedがtrueに更新されること" do
+        put :completed, params: { id: @history.id }
+        expect(@history.reload.completed).to be true
+      end
+    end
+
+    context "非担当メンバーが完了しようとする場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @other_member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status forbiddenが返ってくること" do
+        put :completed, params: { id: @history.id }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        put :completed, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("権限がありません")
+      end
+
+      it "AssignHistoryが更新されないこと" do
+        put :completed, params: { id: @history.id }
+        expect(@history.reload.completed).to be false
+      end
     end
 
     context "存在しないAssignHistoryの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
       it "Status 404が返ってくること" do
         put :completed, params: { id: 999999 }
         expect(response).to have_http_status(:not_found)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        put :completed, params: { id: 999999 }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("担当履歴が見つかりません")
+      end
+    end
+
+    context "既に完了済みの場合" do
+      before do
+        @history.update(completed: true)
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status unprocessable_entityが返ってくること" do
+        put :completed, params: { id: @history.id }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        put :completed, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("既に完了しています")
       end
     end
   end

--- a/spec/services/tasks/completed_spec.rb
+++ b/spec/services/tasks/completed_spec.rb
@@ -201,6 +201,78 @@ RSpec.describe Services::Tasks::Completed, type: :service do
           expect(result.errors).to include("既に完了しています")
         end
       end
+
+      context "ロック例外が発生する場合" do
+        let!(:assign_history) { assign_to_member(task, member) }
+
+        context "Deadlockedが発生する場合" do
+          before do
+            allow(AssignHistory).to receive(:transaction).and_raise(ActiveRecord::Deadlocked.new("deadlock detected"))
+          end
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, admin)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:service_unavailableであること" do
+            result = described_class.new.call({ id: assign_history.id }, admin)
+            expect(result.status).to eq(:service_unavailable)
+          end
+
+          it "混雑エラーメッセージを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, admin)
+            expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+          end
+        end
+
+        context "LockWaitTimeoutが発生する場合" do
+          before do
+            allow(AssignHistory).to receive(:transaction).and_raise(ActiveRecord::LockWaitTimeout.new("lock wait timeout"))
+          end
+
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, admin)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:service_unavailableであること" do
+            result = described_class.new.call({ id: assign_history.id }, admin)
+            expect(result.status).to eq(:service_unavailable)
+          end
+
+          it "混雑エラーメッセージを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, admin)
+            expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+          end
+        end
+      end
+
+      context "保存エラーが発生する場合" do
+        let!(:assign_history) { assign_to_member(task, member) }
+        let(:mock_repository) { instance_double(Services::Tasks::Repository) }
+        let(:service) { described_class.new(repository: mock_repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+          allow(mock_repository).to receive(:complete_assign_history).with(assign_history).and_raise(ActiveRecord::RecordInvalid.new(assign_history))
+        end
+
+        it "success?がfalseを返すこと" do
+          result = service.call({ id: assign_history.id }, admin)
+          expect(result.success?).to be false
+        end
+
+        it "statusが:unprocessable_entityであること" do
+          result = service.call({ id: assign_history.id }, admin)
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "保存失敗エラーメッセージを返すこと" do
+          result = service.call({ id: assign_history.id }, admin)
+          expect(result.errors).to include("タスクの完了処理に失敗しました。")
+        end
+      end
     end
 
     describe "処理順序の検証" do

--- a/spec/services/tasks/completed_spec.rb
+++ b/spec/services/tasks/completed_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::Completed, type: :service do
+  let!(:admin) { create(:account, role: "admin") }
+  let!(:member) { create(:account_member) }
+  let!(:other_member) { create(:account_member) }
+  let!(:area) { create(:area) }
+  let!(:task) { create(:task, area:) }
+
+  # タスクにメンバーを担当者として割り当てる
+  def assign_to_member(task, account, completed: false)
+    cycle = create(:assign_cycle, task:, is_active: true)
+    create(:assign_history, account:, assign_cycle: cycle, completed:, ng: false)
+  end
+
+  describe "#call" do
+    describe "正常系" do
+      context "管理者がタスクを完了する場合" do
+        let!(:assign_history) { assign_to_member(task, member) }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call({ id: assign_history.id }, admin)
+          expect(result.success?).to be true
+        end
+
+        it "statusが:okであること" do
+          result = described_class.new.call({ id: assign_history.id }, admin)
+          expect(result.status).to eq(:ok)
+        end
+
+        it "messageが'change completed'であること" do
+          result = described_class.new.call({ id: assign_history.id }, admin)
+          expect(result.message).to eq("change completed")
+        end
+
+        it "errorsが空であること" do
+          result = described_class.new.call({ id: assign_history.id }, admin)
+          expect(result.errors).to be_empty
+        end
+
+        it "AssignHistoryのcompletedがtrueに更新されること" do
+          described_class.new.call({ id: assign_history.id }, admin)
+          expect(assign_history.reload.completed).to be true
+        end
+
+        it "AssignHistoryのcompleted_atが設定されること" do
+          described_class.new.call({ id: assign_history.id }, admin)
+          expect(assign_history.reload.completed_at).not_to be_nil
+        end
+
+        it "AssignCycleのis_activeがfalseに更新されること" do
+          described_class.new.call({ id: assign_history.id }, admin)
+          expect(assign_history.assign_cycle.reload.is_active).to be false
+        end
+      end
+
+      context "担当メンバーが自分のタスクを完了する場合" do
+        let!(:assign_history) { assign_to_member(task, member) }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call({ id: assign_history.id }, member)
+          expect(result.success?).to be true
+        end
+
+        it "AssignHistoryのcompletedがtrueに更新されること" do
+          described_class.new.call({ id: assign_history.id }, member)
+          expect(assign_history.reload.completed).to be true
+        end
+      end
+
+      context "idが文字列の場合" do
+        let!(:assign_history) { assign_to_member(task, member) }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.new.call({ id: assign_history.id.to_s }, admin)
+          expect(result.success?).to be true
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "認証エラー" do
+        let!(:assign_history) { assign_to_member(task, member) }
+
+        context "current_accountがnilの場合" do
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, nil)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unauthorizedであること" do
+            result = described_class.new.call({ id: assign_history.id }, nil)
+            expect(result.status).to eq(:unauthorized)
+          end
+
+          it "認証エラーメッセージを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, nil)
+            expect(result.errors).to include("認証が必要です")
+          end
+
+          it "AssignHistoryが更新されないこと" do
+            described_class.new.call({ id: assign_history.id }, nil)
+            expect(assign_history.reload.completed).to be false
+          end
+        end
+      end
+
+      context "バリデーションエラー" do
+        context "idが空の場合" do
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call({ id: "" }, admin)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unprocessable_entityであること" do
+            result = described_class.new.call({ id: "" }, admin)
+            expect(result.status).to eq(:unprocessable_entity)
+          end
+        end
+
+        context "idがnilの場合" do
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call({ id: nil }, admin)
+            expect(result.success?).to be false
+          end
+        end
+
+        context "idが非数値の場合" do
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call({ id: "abc" }, admin)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:unprocessable_entityであること" do
+            result = described_class.new.call({ id: "abc" }, admin)
+            expect(result.status).to eq(:unprocessable_entity)
+          end
+        end
+      end
+
+      context "AssignHistoryが存在しない場合" do
+        it "success?がfalseを返すこと" do
+          result = described_class.new.call({ id: 999999 }, admin)
+          expect(result.success?).to be false
+        end
+
+        it "statusが:not_foundであること" do
+          result = described_class.new.call({ id: 999999 }, admin)
+          expect(result.status).to eq(:not_found)
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.new.call({ id: 999999 }, admin)
+          expect(result.errors).to include("担当履歴が見つかりません")
+        end
+      end
+
+      context "認可エラー" do
+        let!(:assign_history) { assign_to_member(task, member) }
+
+        context "非担当メンバーが完了しようとする場合" do
+          it "success?がfalseを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, other_member)
+            expect(result.success?).to be false
+          end
+
+          it "statusが:forbiddenであること" do
+            result = described_class.new.call({ id: assign_history.id }, other_member)
+            expect(result.status).to eq(:forbidden)
+          end
+
+          it "権限エラーメッセージを返すこと" do
+            result = described_class.new.call({ id: assign_history.id }, other_member)
+            expect(result.errors).to include("権限がありません")
+          end
+
+          it "AssignHistoryが更新されないこと" do
+            described_class.new.call({ id: assign_history.id }, other_member)
+            expect(assign_history.reload.completed).to be false
+          end
+        end
+      end
+
+      context "既に完了済みの場合" do
+        let!(:assign_history) { assign_to_member(task, member, completed: true) }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.new.call({ id: assign_history.id }, admin)
+          expect(result.success?).to be false
+        end
+
+        it "statusが:unprocessable_entityであること" do
+          result = described_class.new.call({ id: assign_history.id }, admin)
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.new.call({ id: assign_history.id }, admin)
+          expect(result.errors).to include("既に完了しています")
+        end
+      end
+    end
+
+    describe "処理順序の検証" do
+      let!(:assign_history) { assign_to_member(task, member) }
+
+      it "認証 → バリデーション → 取得 → 認可 → 完了チェック → 実行 の順序で処理されること" do
+        # 認証エラーはバリデーション前に返される
+        result_unauth = described_class.new.call({ id: nil }, nil)
+        expect(result_unauth.status).to eq(:unauthorized)
+
+        # バリデーションエラーは取得前に返される
+        result_invalid = described_class.new.call({ id: nil }, admin)
+        expect(result_invalid.status).to eq(:unprocessable_entity)
+
+        # 存在しないIDはnot_foundを返す（認可チェックより先）
+        result_not_found = described_class.new.call({ id: 999999 }, other_member)
+        expect(result_not_found.status).to eq(:not_found)
+
+        # 認可エラー
+        result_forbidden = described_class.new.call({ id: assign_history.id }, other_member)
+        expect(result_forbidden.status).to eq(:forbidden)
+      end
+    end
+
+    describe "依存性注入" do
+      let!(:assign_cycle) { create(:assign_cycle, task:, is_active: true) }
+      let!(:assign_history) { create(:assign_history, account: member, assign_cycle:, completed: false, ng: false) }
+
+      context "カスタムリポジトリを使用する場合" do
+        let(:mock_repository) { instance_double(Services::Tasks::Repository) }
+        let(:service) { described_class.new(repository: mock_repository) }
+        let(:params) { { id: assign_history.id } }
+
+        before do
+          allow(mock_repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+          allow(mock_repository).to receive(:complete_assign_history).with(assign_history).and_return(true)
+          allow(mock_repository).to receive(:deactivate_cycle).with(assign_cycle).and_return(true)
+        end
+
+        it "指定されたリポジトリのfind_assign_history_with_lockを呼び出すこと" do
+          service.call(params, admin)
+          expect(mock_repository).to have_received(:find_assign_history_with_lock).with(assign_history.id)
+        end
+
+        it "指定されたリポジトリのcomplete_assign_historyを呼び出すこと" do
+          service.call(params, admin)
+          expect(mock_repository).to have_received(:complete_assign_history).with(assign_history)
+        end
+
+        it "指定されたリポジトリのdeactivate_cycleを呼び出すこと" do
+          service.call(params, admin)
+          expect(mock_repository).to have_received(:deactivate_cycle).with(assign_cycle)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tasks/completed_spec.rb
+++ b/spec/services/tasks/completed_spec.rb
@@ -273,6 +273,27 @@ RSpec.describe Services::Tasks::Completed, type: :service do
           expect(result.errors).to include("タスクの完了処理に失敗しました。")
         end
       end
+
+      context "deactivate_cycleが失敗した場合のトランザクションロールバック" do
+        let!(:assign_history) { assign_to_member(task, member) }
+
+        it "AssignHistoryの変更がロールバックされること" do
+          # deactivate_cycleで例外を発生させる
+          allow_any_instance_of(AssignCycle).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(task))
+
+          expect {
+            described_class.new.call({ id: assign_history.id }, admin)
+          }.not_to change { assign_history.reload.completed }
+        end
+
+        it "AssignCycleがアクティブのままであること" do
+          allow_any_instance_of(AssignCycle).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(task))
+
+          expect {
+            described_class.new.call({ id: assign_history.id }, admin)
+          }.not_to change { assign_history.assign_cycle.reload.is_active }
+        end
+      end
     end
 
     describe "処理順序の検証" do

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -272,4 +272,62 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       end
     end
   end
+
+  describe "#find_assign_history_with_lock" do
+    let!(:task) { create(:task, area:) }
+    let!(:account) { create(:account) }
+    let!(:assign_cycle) { create(:assign_cycle, task:) }
+    let!(:assign_history) { create(:assign_history, assign_cycle:, account:) }
+
+    context "存在するIDの場合" do
+      it "AssignHistoryを返すこと" do
+        result = repository.find_assign_history_with_lock(assign_history.id)
+        expect(result).to eq(assign_history)
+      end
+    end
+
+    context "存在しないIDの場合" do
+      it "nilを返すこと" do
+        result = repository.find_assign_history_with_lock(999999)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#complete_assign_history" do
+    let!(:task) { create(:task, area:) }
+    let!(:account) { create(:account) }
+    let!(:assign_cycle) { create(:assign_cycle, task:) }
+    let!(:assign_history) { create(:assign_history, assign_cycle:, account:, completed: false) }
+
+    it "trueを返すこと" do
+      result = repository.complete_assign_history(assign_history)
+      expect(result).to be true
+    end
+
+    it "completedがtrueに更新されること" do
+      repository.complete_assign_history(assign_history)
+      expect(assign_history.reload.completed).to be true
+    end
+
+    it "completed_atが設定されること" do
+      repository.complete_assign_history(assign_history)
+      expect(assign_history.reload.completed_at).not_to be_nil
+    end
+  end
+
+  describe "#deactivate_cycle" do
+    let!(:task) { create(:task, area:) }
+    let!(:assign_cycle) { create(:assign_cycle, task:, is_active: true) }
+
+    it "trueを返すこと" do
+      result = repository.deactivate_cycle(assign_cycle)
+      expect(result).to be true
+    end
+
+    it "is_activeがfalseに更新されること" do
+      repository.deactivate_cycle(assign_cycle)
+      expect(assign_cycle.reload.is_active).to be false
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Tasks#completed エンドポイントを4層アーキテクチャへ移行
- 認証・認可の追加（admin + 担当者のみ完了操作可能）
- 既に完了済みの場合のエラーハンドリング追加

## 変更内容
- Contract: `Contracts::Tasks::Completed` 新規作成（入力検証）
- Service: `Services::Tasks::Completed` 新規作成（完了ユースケース）
- Repository: `find_assign_history_with_lock`, `complete_assign_history`, `deactivate_cycle` 追加
- Controller: `completed` アクションを Service 経由に変更

## 破壊的変更
| 変更 | 影響 |
|-----|------|
| 認証必須化 | フロントエンドは既にトークン送信しているはず |
| 認可追加（admin_or_assignee） | 非担当者は完了操作不可に |
| エラー時レスポンス | `errors` フィールド追加 |

## Test plan
- [x] Contract テスト: 21件 Pass
- [x] Repository テスト: 37件 Pass (7件追加)
- [x] Service テスト: 33件 Pass
- [x] Request テスト: 15件 Pass (13件追加)
- [x] 全テスト: 785件 Pass
- [x] RuboCop: No offenses