### PR TITLE
feat: Tasks#ng を4層アーキテクチャに移行

### DIFF
--- a/app/contracts/tasks/ng.rb
+++ b/app/contracts/tasks/ng.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tasks
+    # タスクNG（辞退）の入力検証
+    # Note: idはAssignHistoryのID（APIパス /tasks/:id/ng の :id は歴史的経緯による命名）
+    class Ng
+      include ActiveModel::Model
+
+      attr_accessor :id
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+
+      def self.call(params)
+        contract = new(id: params[:id])
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { id: id.to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed]
+  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed, :ng]
 
   def index
     result = ::Services::Tasks::Index.new.call(index_params, @current_account)
@@ -73,13 +73,11 @@ class Api::TasksController < ApplicationController
   end
 
   def ng
-    assign_history = AssignHistory.find(params[:id])
-    assign_history.update(ng: true)
-    cycle = AssignCycle.find(assign_history[:assign_cycle_id])
-    if cycle.assign
-      render json: { message: "complete", result: true }
+    result = ::Services::Tasks::Ng.new.call(ng_params, @current_account)
+    if result.success?
+      render json: { message: result.message, result: true }, status: result.status
     else
-      render json: { message: "failed", result: false }
+      render json: { message: "failed", result: false, errors: result.errors }, status: result.status
     end
   end
 
@@ -126,6 +124,10 @@ class Api::TasksController < ApplicationController
     end
 
     def completed_params
+      { id: params[:id] }
+    end
+
+    def ng_params
       { id: params[:id] }
     end
 

--- a/app/services/tasks/ng.rb
+++ b/app/services/tasks/ng.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    # タスクNG（辞退）処理
+    class Ng
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # Contract検証
+        validation = ::Contracts::Tasks::Ng.call(params)
+        return failure(validation.errors, :unprocessable_entity) unless validation.success?
+
+        # トランザクション内で処理
+        AssignHistory.transaction do
+          # AssignHistory取得（悲観的ロック）
+          assign_history = @repository.find_assign_history_with_lock(validation.value[:id])
+          return failure(["担当履歴が見つかりません"], :not_found) if assign_history.nil?
+
+          # 関連するTaskを取得
+          task = assign_history.assign_cycle.task
+
+          # 認可チェック（管理者 または 現在のアクティブな担当者のみ）
+          unless can_mark_ng?(current_account, task)
+            return failure(["権限がありません"], :forbidden)
+          end
+
+          # 既にNG済みチェック
+          if assign_history.ng?
+            return failure(["既にNGです"], :unprocessable_entity)
+          end
+
+          # 既に完了済みチェック
+          if assign_history.completed?
+            return failure(["既に完了しています"], :unprocessable_entity)
+          end
+
+          # NG処理実行
+          @repository.mark_ng(assign_history)
+
+          # 再割り当て実行
+          cycle = assign_history.assign_cycle
+          reassign_success = cycle.assign
+
+          Rails.logger.info "Task NG: assign_history_id=#{assign_history.id}, task_id=#{task.id}, by_account=#{current_account.id}, reassigned=#{reassign_success}"
+
+          if reassign_success
+            success("complete")
+          else
+            success("failed") # NGは成功、再割り当てのみ失敗
+          end
+        end
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Task NG lock error: id=#{params[:id]}, error=#{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error "Task NG save error: id=#{params[:id]}, error=#{e.message}"
+        failure(["NG処理に失敗しました。"], :unprocessable_entity)
+      end
+
+      private
+        def can_mark_ng?(account, task)
+          policy = ::Policies::AccountPolicy.new(account)
+          return true if policy.admin_only?
+
+          task.current_assignee?(account)
+        end
+
+        def success(message)
+          NgResult.new(success?: true, message:, errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          NgResult.new(success?: false, message: "failed", errors:, status:)
+        end
+    end
+
+    # Ng専用Result（後方互換性のためmessageを返す）
+    NgResult = Struct.new(:success?, :message, :errors, :status, keyword_init: true)
+  end
+end

--- a/app/services/tasks/ng.rb
+++ b/app/services/tasks/ng.rb
@@ -45,13 +45,14 @@ module Services
 
           # 再割り当て実行
           cycle = assign_history.assign_cycle
-          reassign_success = cycle.assign
+          reassign_result = cycle.assign
 
-          Rails.logger.info "Task NG: assign_history_id=#{assign_history.id}, task_id=#{task.id}, by_account=#{current_account.id}, reassigned=#{reassign_success}"
-
-          if reassign_success
+          if reassign_result
+            Rails.logger.info "Task NG: assign_history_id=#{assign_history.id}, task_id=#{task.id}, by_account=#{current_account.id}, reassigned=true, new_assignee_id=#{reassign_result.account_id}"
             success("complete")
           else
+            # 再割り当て失敗: 適格者なし または 保存失敗
+            Rails.logger.warn "Task NG reassignment failed: assign_history_id=#{assign_history.id}, task_id=#{task.id}, cycle_id=#{cycle.id}, no_eligible_accounts_or_save_failed=true"
             success("failed") # NGは成功、再割り当てのみ失敗
           end
         end

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -72,7 +72,7 @@ module Services
         true
       end
 
-      # AssignHistoryをIDで取得（悲観的ロック付き - 同時完了操作によるレースコンディション防止）
+      # AssignHistoryをIDで取得（悲観的ロック付き - 完了/NG操作の同時実行によるレースコンディション防止）
       def find_assign_history_with_lock(id)
         AssignHistory.lock.find_by(id:)
       end

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -88,6 +88,12 @@ module Services
       def deactivate_cycle(cycle)
         cycle.update!(is_active: false)
       end
+
+      # AssignHistoryのNG処理（Service層からの呼び出し用）
+      # @raise [ActiveRecord::RecordInvalid] バリデーション失敗時
+      def mark_ng(assign_history)
+        assign_history.update!(ng: true)
+      end
     end
   end
 end

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -24,7 +24,7 @@ Controller → Contract → Service → Repository → Model
 |--------------|---------|-------|------|
 | Accounts | 6/6 | 0 | ✅ 完了 |
 | Authentications | 1/1 | 0 | ✅ 完了 |
-| Tasks | 8/12 | 4 | 🔶 進行中 |
+| Tasks | 9/12 | 3 | 🔶 進行中 |
 | Areas | 0/5 | 5 | ⬜ 未着手 |
 | Comments | 0/5 | 5 | ⬜ 未着手 |
 | Tags | 0/4 | 4 | ⬜ 未着手 |
@@ -32,7 +32,7 @@ Controller → Contract → Service → Repository → Model
 | AccountAreas | 0/2 | 2 | ⬜ 未着手 |
 | TagAccounts | 0/2 | 2 | ⬜ 未着手 |
 
-**合計: 15/38 (39%)**
+**合計: 16/38 (42%)**
 
 ---
 
@@ -76,13 +76,14 @@ Controller → Contract → Service → Repository → Model
   - Service: `Services::Tasks::Completed`
   - Repository: `find_assign_history_with_lock`, `complete_assign_history`, `deactivate_cycle`追加
   - 認証必須化、認可追加（admin + 担当者）
-
-### 未移行
-
-- [ ] `PUT /api/tasks/:id/ng` (ng)
+- [x] `PUT /api/tasks/:id/ng` (ng)
   - Contract: `Contracts::Tasks::Ng`
   - Service: `Services::Tasks::Ng`
-  - Note: AssignHistory + AssignCycle.assign 呼び出し
+  - Repository: `mark_ng`追加
+  - 認証必須化、認可追加（admin + 担当者）
+  - Note: NGマーク後にAssignCycle.assign で再割り当て実行
+
+### 未移行
 
 - [ ] `POST /api/tasks/:id/newCycle` (create_new_cycle)
   - Contract: `Contracts::Tasks::CreateNewCycle`
@@ -205,6 +206,7 @@ Controller → Contract → Service → Repository → Model
 | `GET /api/tasks/:id` | 認証必須化、Presenter経由レスポンス | - |
 | `PUT /api/tasks/:id` | 認証必須化、認可追加(admin+担当者)、`is_complete`削除、Presenter経由レスポンス | - |
 | `DELETE /api/tasks/:id` | 認証必須化、認可追加(admin_only)、レスポンス: 204→200+message | - |
+| `PUT /api/tasks/:id/ng` | 認証必須化、認可追加(admin+担当者)、errors追加 | - |
 
 ---
 

--- a/spec/contracts/tasks/ng_spec.rb
+++ b/spec/contracts/tasks/ng_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tasks::Ng do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "idが文字列の整数の場合" do
+        let(:params) { { id: "1" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ id: 1 })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "idが整数の場合" do
+        let(:params) { { id: 123 } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "idが整数に変換されること" do
+          result = described_class.call(params)
+          expect(result.value[:id]).to eq(123)
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "idが空文字列の場合" do
+        let(:params) { { id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idがnilの場合" do
+        let(:params) { { id: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "パラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idが非数値の場合" do
+        let(:params) { { id: "abc" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id is not a number")
+        end
+      end
+
+      context "idが0の場合" do
+        let(:params) { { id: "0" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+
+      context "idが負数の場合" do
+        let(:params) { { id: "-1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+
+      context "idが小数の場合" do
+        let(:params) { { id: "1.5" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be an integer")
+        end
+      end
+    end
+  end
+
+  describe "#normalized_attributes" do
+    context "文字列のidの場合" do
+      it "idが整数に変換されること" do
+        contract = described_class.new(id: "42")
+        expect(contract.normalized_attributes).to eq({ id: 42 })
+      end
+    end
+
+    context "整数のidの場合" do
+      it "idがそのまま返されること" do
+        contract = described_class.new(id: 100)
+        expect(contract.normalized_attributes).to eq({ id: 100 })
+      end
+    end
+  end
+end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -780,6 +780,58 @@ RSpec.describe Api::TasksController, type: :controller do
         expect(json_response["errors"]).to include("既に完了しています")
       end
     end
+
+    context "NG後に再割り当てが実行される場合" do
+      before do
+        @another_member = create(:account_member)
+        @another_member.add_area(@area)
+        token = JsonWebToken.encode({ account_id: @member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "新しいAssignHistoryが作成されること" do
+        expect {
+          put :ng, params: { id: @history.id }
+        }.to change(AssignHistory, :count).by(1)
+      end
+
+      it "新しい担当者に割り当てられること" do
+        put :ng, params: { id: @history.id }
+        new_history = @cycle.assign_histories.where.not(id: @history.id).last
+        expect(new_history.account_id).to eq(@another_member.id)
+      end
+
+      it "messageがcompleteを返すこと" do
+        put :ng, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["message"]).to eq("complete")
+      end
+    end
+
+    context "再割り当て対象者がいない場合" do
+      before do
+        # memberが唯一のエリア担当者で、NG済みになるため再割り当て不可
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 200が返ること（NG自体は成功）" do
+        put :ng, params: { id: @history.id }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "messageがfailedを返すこと" do
+        put :ng, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["message"]).to eq("failed")
+      end
+
+      it "resultがtrueを返すこと（NG操作自体は成功）" do
+        put :ng, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["result"]).to be true
+      end
+    end
   end
 
   describe "POST #create_new_cycle" do

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -645,31 +645,139 @@ RSpec.describe Api::TasksController, type: :controller do
 
   describe "PUT #ng" do
     before do
+      @admin = create(:account)
       @member = create(:account_member)
+      @other_member = create(:account_member)
       @area = create(:area)
       @member.add_area(@area)
       @task = create(:task, area_id: @area.id)
-      @cycle = create(:assign_cycle, task_id: @task.id)
-      @history = create(:assign_history, account_id: @member.id, assign_cycle_id: @cycle.id, ng: false)
+      @cycle = create(:assign_cycle, task_id: @task.id, is_active: true)
+      @history = create(:assign_history, account_id: @member.id, assign_cycle_id: @cycle.id, ng: false, completed: false)
     end
 
-    context "有効なパラメータの場合" do
+    context "認証なしの場合" do
+      it "Status 401が返ってくること" do
+        put :ng, params: { id: @history.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "管理者がNG操作する場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
       it "Status 200が返ってくること" do
         put :ng, params: { id: @history.id }
         expect(response).to have_http_status(:ok)
       end
 
-      it "ngがtrueになること" do
+      it "resultがtrueを返すこと" do
         put :ng, params: { id: @history.id }
-        @history.reload
-        expect(@history.ng).to be true
+        json_response = JSON.parse(response.body)
+        expect(json_response["result"]).to be true
+      end
+
+      it "AssignHistoryのngがtrueに更新されること" do
+        put :ng, params: { id: @history.id }
+        expect(@history.reload.ng).to be true
+      end
+    end
+
+    context "担当メンバーが自分のタスクをNG操作する場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 200が返ってくること" do
+        put :ng, params: { id: @history.id }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "AssignHistoryのngがtrueに更新されること" do
+        put :ng, params: { id: @history.id }
+        expect(@history.reload.ng).to be true
+      end
+    end
+
+    context "非担当メンバーがNG操作しようとする場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @other_member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status forbiddenが返ってくること" do
+        put :ng, params: { id: @history.id }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        put :ng, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("権限がありません")
+      end
+
+      it "AssignHistoryが更新されないこと" do
+        put :ng, params: { id: @history.id }
+        expect(@history.reload.ng).to be false
       end
     end
 
     context "存在しないAssignHistoryの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
       it "Status 404が返ってくること" do
         put :ng, params: { id: 999999 }
         expect(response).to have_http_status(:not_found)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        put :ng, params: { id: 999999 }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("担当履歴が見つかりません")
+      end
+    end
+
+    context "既にNGの場合" do
+      before do
+        @history.update(ng: true)
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status unprocessable_entityが返ってくること" do
+        put :ng, params: { id: @history.id }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        put :ng, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("既にNGです")
+      end
+    end
+
+    context "既に完了済みの場合" do
+      before do
+        @history.update(completed: true)
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status unprocessable_entityが返ってくること" do
+        put :ng, params: { id: @history.id }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        put :ng, params: { id: @history.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("既に完了しています")
       end
     end
   end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -743,6 +743,28 @@ RSpec.describe Api::TasksController, type: :controller do
       end
     end
 
+    context "無効なIDフォーマットの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "非数値IDでStatus 422が返ること" do
+        put :ng, params: { id: "invalid" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "0のIDでStatus 422が返ること" do
+        put :ng, params: { id: "0" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "負数のIDでStatus 422が返ること" do
+        put :ng, params: { id: "-1" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
     context "既にNGの場合" do
       before do
         @history.update(ng: true)

--- a/spec/services/tasks/ng_spec.rb
+++ b/spec/services/tasks/ng_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::Ng, type: :service do
+  let(:repository) { instance_double(Services::Tasks::Repository) }
+  let(:service) { described_class.new(repository:) }
+
+  describe "#call" do
+    let!(:admin) { create(:account) }
+    let!(:member) { create(:account_member) }
+    let!(:other_member) { create(:account_member) }
+    let!(:area) { create(:area) }
+    let!(:task) { create(:task, area:) }
+    let!(:assign_cycle) { create(:assign_cycle, task:, is_active: true) }
+    let!(:assign_history) { create(:assign_history, assign_cycle:, account: member, ng: false, completed: false) }
+
+    before do
+      # タスクの現在の担当者として設定
+      allow(task).to receive(:current_assignee?).with(admin).and_return(false)
+      allow(task).to receive(:current_assignee?).with(member).and_return(true)
+      allow(task).to receive(:current_assignee?).with(other_member).and_return(false)
+    end
+
+    context "認証されていない場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      it "unauthorizedを返すこと" do
+        result = service.call(params, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unauthorized)
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "Contract検証に失敗した場合" do
+      let(:params) { { id: "invalid" } }
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+      end
+    end
+
+    context "AssignHistoryが存在しない場合" do
+      let(:params) { { id: "999999" } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(999999).and_return(nil)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("担当履歴が見つかりません")
+      end
+    end
+
+    context "権限がない場合（非担当メンバー）" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+      end
+
+      it "forbiddenを返すこと" do
+        result = service.call(params, other_member)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:forbidden)
+        expect(result.errors).to include("権限がありません")
+      end
+    end
+
+    context "既にNGの場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+      let!(:ng_history) { create(:assign_history, assign_cycle:, account: member, ng: true, completed: false) }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(ng_history.id).and_return(ng_history)
+      end
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call({ id: ng_history.id.to_s }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors).to include("既にNGです")
+      end
+    end
+
+    context "既に完了している場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+      let!(:completed_history) { create(:assign_history, assign_cycle:, account: member, ng: false, completed: true) }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(completed_history.id).and_return(completed_history)
+      end
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call({ id: completed_history.id.to_s }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors).to include("既に完了しています")
+      end
+    end
+
+    context "管理者がNG操作する場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+        allow(repository).to receive(:mark_ng).with(assign_history).and_return(true)
+        allow(assign_cycle).to receive(:assign).and_return(true)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "mark_ngを呼び出すこと" do
+        service.call(params, admin)
+        expect(repository).to have_received(:mark_ng).with(assign_history)
+      end
+    end
+
+    context "担当者が自分のタスクをNG操作する場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+        allow(repository).to receive(:mark_ng).with(assign_history).and_return(true)
+        allow(assign_cycle).to receive(:assign).and_return(true)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(params, member)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+    end
+
+    context "再割り当てが成功した場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+        allow(repository).to receive(:mark_ng).with(assign_history).and_return(true)
+        allow(assign_cycle).to receive(:assign).and_return(true)
+      end
+
+      it "message が 'complete' を返すこと" do
+        result = service.call(params, admin)
+        expect(result.message).to eq("complete")
+      end
+
+      it "assign が呼び出されること" do
+        service.call(params, admin)
+        expect(assign_cycle).to have_received(:assign)
+      end
+    end
+
+    context "再割り当てが失敗した場合（適格者なし）" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+        allow(repository).to receive(:mark_ng).with(assign_history).and_return(true)
+        allow(assign_cycle).to receive(:assign).and_return(false)
+      end
+
+      it "成功を返すこと（NGマーク自体は成功）" do
+        result = service.call(params, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "message が 'failed' を返すこと" do
+        result = service.call(params, admin)
+        expect(result.message).to eq("failed")
+      end
+    end
+
+    context "Deadlocked例外が発生した場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).and_raise(ActiveRecord::Deadlocked.new("Deadlock"))
+      end
+
+      it "service_unavailableを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+        expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+      end
+    end
+
+    context "LockWaitTimeout例外が発生した場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).and_raise(ActiveRecord::LockWaitTimeout.new("Timeout"))
+      end
+
+      it "service_unavailableを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+      end
+    end
+
+    context "RecordInvalid例外が発生した場合" do
+      let(:params) { { id: assign_history.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
+        allow(repository).to receive(:mark_ng).and_raise(ActiveRecord::RecordInvalid.new(assign_history))
+      end
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors).to include("NG処理に失敗しました。")
+      end
+    end
+  end
+
+  describe "依存性注入" do
+    it "デフォルトでRepositoryを使用すること" do
+      service = described_class.new
+      expect(service.instance_variable_get(:@repository)).to be_a(Services::Tasks::Repository)
+    end
+
+    it "カスタムRepositoryを注入できること" do
+      custom_repo = instance_double(Services::Tasks::Repository)
+      service = described_class.new(repository: custom_repo)
+      expect(service.instance_variable_get(:@repository)).to eq(custom_repo)
+    end
+  end
+end

--- a/spec/services/tasks/ng_spec.rb
+++ b/spec/services/tasks/ng_spec.rb
@@ -107,11 +107,12 @@ RSpec.describe Services::Tasks::Ng, type: :service do
 
     context "管理者がNG操作する場合" do
       let(:params) { { id: assign_history.id.to_s } }
+      let(:new_assign_history) { instance_double(AssignHistory, account_id: other_member.id) }
 
       before do
         allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
         allow(repository).to receive(:mark_ng).with(assign_history).and_return(true)
-        allow(assign_cycle).to receive(:assign).and_return(true)
+        allow(assign_cycle).to receive(:assign).and_return(new_assign_history)
       end
 
       it "成功を返すこと" do
@@ -128,11 +129,12 @@ RSpec.describe Services::Tasks::Ng, type: :service do
 
     context "担当者が自分のタスクをNG操作する場合" do
       let(:params) { { id: assign_history.id.to_s } }
+      let(:new_assign_history) { instance_double(AssignHistory, account_id: other_member.id) }
 
       before do
         allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
         allow(repository).to receive(:mark_ng).with(assign_history).and_return(true)
-        allow(assign_cycle).to receive(:assign).and_return(true)
+        allow(assign_cycle).to receive(:assign).and_return(new_assign_history)
       end
 
       it "成功を返すこと" do
@@ -144,11 +146,12 @@ RSpec.describe Services::Tasks::Ng, type: :service do
 
     context "再割り当てが成功した場合" do
       let(:params) { { id: assign_history.id.to_s } }
+      let(:new_assign_history) { instance_double(AssignHistory, account_id: other_member.id) }
 
       before do
         allow(repository).to receive(:find_assign_history_with_lock).with(assign_history.id).and_return(assign_history)
         allow(repository).to receive(:mark_ng).with(assign_history).and_return(true)
-        allow(assign_cycle).to receive(:assign).and_return(true)
+        allow(assign_cycle).to receive(:assign).and_return(new_assign_history)
       end
 
       it "message が 'complete' を返すこと" do

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -346,5 +346,12 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       repository.mark_ng(assign_history)
       expect(assign_history.reload.ng).to be true
     end
+
+    context "バリデーションエラーが発生した場合" do
+      it "ActiveRecord::RecordInvalidを発生させること" do
+        allow(assign_history).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(assign_history))
+        expect { repository.mark_ng(assign_history) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 end

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -330,4 +330,21 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       expect(assign_cycle.reload.is_active).to be false
     end
   end
+
+  describe "#mark_ng" do
+    let!(:task) { create(:task, area:) }
+    let!(:account) { create(:account) }
+    let!(:assign_cycle) { create(:assign_cycle, task:) }
+    let!(:assign_history) { create(:assign_history, assign_cycle:, account:, ng: false) }
+
+    it "trueを返すこと" do
+      result = repository.mark_ng(assign_history)
+      expect(result).to be true
+    end
+
+    it "ngがtrueに更新されること" do
+      repository.mark_ng(assign_history)
+      expect(assign_history.reload.ng).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Tasks#ng エンドポイントを4層アーキテクチャに移行
- 認証必須化（セキュリティ修正）
- 認可追加: admin または現在の担当者のみ操作可能
- トランザクション処理の追加

## 主な変更
### 新規作成
- `app/contracts/tasks/ng.rb` - 入力検証
- `app/services/tasks/ng.rb` - ユースケース
- `spec/contracts/tasks/ng_spec.rb` - Contract テスト（21件）
- `spec/services/tasks/ng_spec.rb` - Service テスト（18件）

### 修正
- `app/controllers/api/tasks_controller.rb` - Service 呼び出しに変更、before_action 追加
- `app/services/tasks/repository.rb` - `mark_ng` メソッド追加
- `spec/requests/api/tasks_spec.rb` - 認証・認可テスト追加（15件）
- `spec/services/tasks/repository_spec.rb` - Repository テスト追加（2件）
- `docs/todo/TODO.md` - 進捗更新（42%）

## 破壊的変更
| 変更 | 影響 |
|-----|------|
| 認証必須化 | トークンなしで401 |
| 認可追加 | 非担当者は403 |
| errors追加 | エラー時にerrorsフィールドあり |

## Test plan
- [x] RSpec 全テスト Pass（849件）
- [x] RuboCop Pass
- [x] 認証なし → 401
- [x] 管理者 → 200
- [x] 担当メンバー → 200
- [x] 非担当メンバー → 403
- [x] 存在しないID → 404
- [x] 既にNG → 422
- [x] 既に完了済み → 422