### PR TITLE
feat: Tasks#create_new_cycle を4層アーキテクチャへ移行

### DIFF
--- a/app/contracts/tasks/create_new_cycle.rb
+++ b/app/contracts/tasks/create_new_cycle.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tasks
+    # 新サイクル作成の入力検証
+    # Note: idはTaskのID
+    class CreateNewCycle
+      include ActiveModel::Model
+
+      attr_accessor :id
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+
+      def self.call(params)
+        contract = new(id: params[:id])
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { id: id.to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed, :ng]
+  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed, :ng, :create_new_cycle]
 
   def index
     result = ::Services::Tasks::Index.new.call(index_params, @current_account)
@@ -63,12 +63,9 @@ class Api::TasksController < ApplicationController
   end
 
   def create_new_cycle
-    task = Task.find(params[:id])
-    cycle = task.create_new_cycle
-    if cycle.assign
-      render json: task
-    else
-      render json: { status: 422 }
+    result = ::Services::Tasks::CreateNewCycle.new.call(create_new_cycle_params, @current_account)
+    render_result(result) do
+      ::Presenters::TaskPresenter.render_task(result.task)
     end
   end
 
@@ -128,6 +125,10 @@ class Api::TasksController < ApplicationController
     end
 
     def ng_params
+      { id: params[:id] }
+    end
+
+    def create_new_cycle_params
       { id: params[:id] }
     end
 

--- a/app/services/tasks/create_new_cycle.rb
+++ b/app/services/tasks/create_new_cycle.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    # 新サイクル作成処理（タスクの再起動）
+    class CreateNewCycle
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], nil, :unauthorized) if current_account.nil?
+
+        # 認可チェック（admin_only）
+        policy = ::Policies::AccountPolicy.new(current_account)
+        return failure(["権限がありません"], nil, :forbidden) unless policy.admin_only?
+
+        # Contract検証
+        validation = ::Contracts::Tasks::CreateNewCycle.call(params)
+        return failure(validation.errors, nil, :unprocessable_entity) unless validation.success?
+
+        # トランザクション内で処理
+        Task.transaction do
+          # Task取得（悲観的ロック）
+          task = @repository.find_by_id_with_lock(validation.value[:id])
+          return failure(["タスクが見つかりません"], nil, :not_found) if task.nil?
+
+          # 既存サイクルを非アクティブ化
+          @repository.deactivate_all_cycles(task)
+
+          # 新サイクル作成
+          cycle = @repository.create_cycle(task)
+
+          # 割り当て実行
+          assign_result = cycle.assign
+
+          if assign_result
+            Rails.logger.info "New cycle created: task_id=#{task.id}, cycle_id=#{cycle.id}, by_account=#{current_account.id}, assignee_id=#{assign_result.account_id}"
+            success(task)
+          else
+            Rails.logger.warn "New cycle created but assignment failed: task_id=#{task.id}, cycle_id=#{cycle.id}, no_eligible_accounts=true"
+            failure(["割り当て可能なメンバーがいません"], task, :unprocessable_entity)
+          end
+        end
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "CreateNewCycle lock error: id=#{params[:id]}, error=#{e.message}"
+        failure(["サーバーが混雑しています"], nil, :service_unavailable)
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error "CreateNewCycle save error: id=#{params[:id]}, error=#{e.message}"
+        failure(["サイクル作成に失敗しました"], nil, :unprocessable_entity)
+      end
+
+      private
+        def success(task)
+          CreateNewCycleResult.new(success?: true, task:, message: nil, errors: [], status: :ok)
+        end
+
+        def failure(errors, task, status)
+          CreateNewCycleResult.new(success?: false, task:, message: "failed", errors:, status:)
+        end
+    end
+
+    # CreateNewCycle専用Result
+    CreateNewCycleResult = Struct.new(:success?, :task, :message, :errors, :status, keyword_init: true)
+  end
+end

--- a/app/services/tasks/create_new_cycle.rb
+++ b/app/services/tasks/create_new_cycle.rb
@@ -21,13 +21,18 @@ module Services
         return failure(validation.errors, nil, :unprocessable_entity) unless validation.success?
 
         # トランザクション内で処理
+        result = nil
         Task.transaction do
           # Task取得（悲観的ロック）
           task = @repository.find_by_id_with_lock(validation.value[:id])
-          return failure(["タスクが見つかりません"], nil, :not_found) if task.nil?
+          if task.nil?
+            result = failure(["タスクが見つかりません"], nil, :not_found)
+            raise ActiveRecord::Rollback
+          end
 
           # 既存サイクルを非アクティブ化
-          @repository.deactivate_all_cycles(task)
+          deactivated_count = @repository.deactivate_all_cycles(task)
+          Rails.logger.debug "Deactivated #{deactivated_count} cycles for task_id=#{task.id}"
 
           # 新サイクル作成
           cycle = @repository.create_cycle(task)
@@ -37,12 +42,14 @@ module Services
 
           if assign_result
             Rails.logger.info "New cycle created: task_id=#{task.id}, cycle_id=#{cycle.id}, by_account=#{current_account.id}, assignee_id=#{assign_result.account_id}"
-            success(task)
+            result = success(task)
           else
             Rails.logger.warn "New cycle created but assignment failed: task_id=#{task.id}, cycle_id=#{cycle.id}, no_eligible_accounts=true"
-            failure(["割り当て可能なメンバーがいません"], task, :unprocessable_entity)
+            result = failure(["割り当て可能なメンバーがいません"], nil, :unprocessable_entity)
+            raise ActiveRecord::Rollback
           end
         end
+        result
       rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
         Rails.logger.error "CreateNewCycle lock error: id=#{params[:id]}, error=#{e.message}"
         failure(["サーバーが混雑しています"], nil, :service_unavailable)

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -96,6 +96,7 @@ module Services
       end
 
       # タスクの全サイクルを非アクティブ化（一括更新）
+      # Note: update_allはバリデーションを実行しないため例外は発生しない
       # @return [Integer] 更新された行数
       def deactivate_all_cycles(task)
         AssignCycle.where(task_id: task.id).update_all(is_active: false)
@@ -103,8 +104,9 @@ module Services
 
       # 新しいサイクルを作成
       # @return [AssignCycle] 作成されたサイクル
+      # @raise [ActiveRecord::RecordInvalid] バリデーション失敗時
       def create_cycle(task)
-        task.assign_cycles.create
+        task.assign_cycles.create!
       end
     end
   end

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -94,6 +94,18 @@ module Services
       def mark_ng(assign_history)
         assign_history.update!(ng: true)
       end
+
+      # タスクの全サイクルを非アクティブ化（一括更新）
+      # @return [Integer] 更新された行数
+      def deactivate_all_cycles(task)
+        AssignCycle.where(task_id: task.id).update_all(is_active: false)
+      end
+
+      # 新しいサイクルを作成
+      # @return [AssignCycle] 作成されたサイクル
+      def create_cycle(task)
+        task.assign_cycles.create
+      end
     end
   end
 end

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -24,7 +24,7 @@ Controller → Contract → Service → Repository → Model
 |--------------|---------|-------|------|
 | Accounts | 6/6 | 0 | ✅ 完了 |
 | Authentications | 1/1 | 0 | ✅ 完了 |
-| Tasks | 9/12 | 3 | 🔶 進行中 |
+| Tasks | 10/12 | 2 | 🔶 進行中 |
 | Areas | 0/5 | 5 | ⬜ 未着手 |
 | Comments | 0/5 | 5 | ⬜ 未着手 |
 | Tags | 0/4 | 4 | ⬜ 未着手 |
@@ -32,7 +32,7 @@ Controller → Contract → Service → Repository → Model
 | AccountAreas | 0/2 | 2 | ⬜ 未着手 |
 | TagAccounts | 0/2 | 2 | ⬜ 未着手 |
 
-**合計: 16/38 (42%)**
+**合計: 17/38 (45%)**
 
 ---
 
@@ -82,13 +82,14 @@ Controller → Contract → Service → Repository → Model
   - Repository: `mark_ng`追加
   - 認証必須化、認可追加（admin + 担当者）
   - Note: NGマーク後にAssignCycle.assign で再割り当て実行
-
-### 未移行
-
-- [ ] `POST /api/tasks/:id/newCycle` (create_new_cycle)
+- [x] `POST /api/tasks/:id/newCycle` (create_new_cycle)
   - Contract: `Contracts::Tasks::CreateNewCycle`
   - Service: `Services::Tasks::CreateNewCycle`
-  - Note: Task + AssignCycle操作
+  - Repository: `deactivate_all_cycles`, `create_cycle`追加
+  - Presenter: `TaskPresenter.render_task`（既存）
+  - 認証必須化、認可追加（admin_only）
+
+### 未移行
 
 - [ ] `GET /api/unfulfilled-count` (unfulfilleds_count)
   - Service: `Services::Tasks::UnfulfilledsCount`

--- a/spec/contracts/tasks/create_new_cycle_spec.rb
+++ b/spec/contracts/tasks/create_new_cycle_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tasks::CreateNewCycle do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "idが文字列の整数の場合" do
+        let(:params) { { id: "1" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ id: 1 })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "idが整数の場合" do
+        let(:params) { { id: 123 } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "idが整数に変換されること" do
+          result = described_class.call(params)
+          expect(result.value[:id]).to eq(123)
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "idが空文字列の場合" do
+        let(:params) { { id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idがnilの場合" do
+        let(:params) { { id: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "パラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id can't be blank")
+        end
+      end
+
+      context "idが非数値の場合" do
+        let(:params) { { id: "abc" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id is not a number")
+        end
+      end
+
+      context "idが0の場合" do
+        let(:params) { { id: "0" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+
+      context "idが負数の場合" do
+        let(:params) { { id: "-1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be greater than 0")
+        end
+      end
+
+      context "idが小数の場合" do
+        let(:params) { { id: "1.5" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors).to include("Id must be an integer")
+        end
+      end
+    end
+  end
+
+  describe "#normalized_attributes" do
+    context "文字列のidの場合" do
+      it "idが整数に変換されること" do
+        contract = described_class.new(id: "42")
+        expect(contract.normalized_attributes).to eq({ id: 42 })
+      end
+    end
+
+    context "整数のidの場合" do
+      it "idがそのまま返されること" do
+        contract = described_class.new(id: 100)
+        expect(contract.normalized_attributes).to eq({ id: 100 })
+      end
+    end
+  end
+end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -858,13 +858,44 @@ RSpec.describe Api::TasksController, type: :controller do
 
   describe "POST #create_new_cycle" do
     before do
+      @admin = create(:account)
       @member = create(:account_member)
       @area = create(:area)
       @member.add_area(@area)
       @task = create(:task, area_id: @area.id)
     end
 
-    context "有効なパラメータの場合" do
+    context "認証なしの場合" do
+      it "Status 401が返ること" do
+        post :create_new_cycle, params: { id: @task.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context "一般メンバーの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @member.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 403が返ること" do
+        post :create_new_cycle, params: { id: @task.id }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "エラーメッセージが返ること" do
+        post :create_new_cycle, params: { id: @task.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("権限がありません")
+      end
+    end
+
+    context "管理者で有効なパラメータの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
       it "Status 200が返ってくること" do
         post :create_new_cycle, params: { id: @task.id }
         expect(response).to have_http_status(:ok)
@@ -875,12 +906,77 @@ RSpec.describe Api::TasksController, type: :controller do
           post :create_new_cycle, params: { id: @task.id }
         }.to change(AssignCycle, :count).by(1)
       end
+
+      it "Presenter形式でタスクが返ること" do
+        post :create_new_cycle, params: { id: @task.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["task_title"]).to eq(@task.task_title)
+      end
     end
 
-    context "存在しないタスクの場合" do
+    context "管理者で存在しないタスクの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
       it "Status 404が返ってくること" do
         post :create_new_cycle, params: { id: 999999 }
         expect(response).to have_http_status(:not_found)
+      end
+
+      it "エラーメッセージが返ること" do
+        post :create_new_cycle, params: { id: 999999 }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("タスクが見つかりません")
+      end
+    end
+
+    context "管理者で割り当て可能なメンバーがいない場合" do
+      before do
+        # メンバーをエリアから外す
+        @member.areas.delete(@area)
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 422が返ること" do
+        post :create_new_cycle, params: { id: @task.id }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "エラーメッセージが返ること" do
+        post :create_new_cycle, params: { id: @task.id }
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("割り当て可能なメンバーがいません")
+      end
+
+      it "サイクルは作成されていること" do
+        expect {
+          post :create_new_cycle, params: { id: @task.id }
+        }.to change(AssignCycle, :count).by(1)
+      end
+    end
+
+    context "無効なIDフォーマットの場合" do
+      before do
+        token = JsonWebToken.encode({ account_id: @admin.id })
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "文字列のIDでStatus 422が返ること" do
+        post :create_new_cycle, params: { id: "abc" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "0のIDでStatus 422が返ること" do
+        post :create_new_cycle, params: { id: "0" }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "負のIDでStatus 422が返ること" do
+        post :create_new_cycle, params: { id: "-1" }
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -951,10 +951,10 @@ RSpec.describe Api::TasksController, type: :controller do
         expect(json_response["errors"]).to include("割り当て可能なメンバーがいません")
       end
 
-      it "サイクルは作成されていること" do
+      it "サイクルは作成されないこと（トランザクションがロールバックされるため）" do
         expect {
           post :create_new_cycle, params: { id: @task.id }
-        }.to change(AssignCycle, :count).by(1)
+        }.not_to change(AssignCycle, :count)
       end
     end
 

--- a/spec/services/tasks/create_new_cycle_spec.rb
+++ b/spec/services/tasks/create_new_cycle_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::CreateNewCycle, type: :service do
+  let(:repository) { instance_double(Services::Tasks::Repository) }
+  let(:service) { described_class.new(repository:) }
+
+  describe "#call" do
+    let!(:admin) { create(:account) }
+    let!(:member) { create(:account_member) }
+    let!(:area) { create(:area) }
+    let!(:task) { create(:task, area:) }
+
+    context "認証されていない場合" do
+      let(:params) { { id: task.id.to_s } }
+
+      it "unauthorizedを返すこと" do
+        result = service.call(params, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unauthorized)
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "管理者ではない場合" do
+      let(:params) { { id: task.id.to_s } }
+
+      it "forbiddenを返すこと" do
+        result = service.call(params, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:forbidden)
+        expect(result.errors).to include("権限がありません")
+      end
+    end
+
+    context "Contract検証に失敗した場合" do
+      let(:params) { { id: "invalid" } }
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+      end
+
+      it "Contractのエラーメッセージを返すこと" do
+        result = service.call(params, admin)
+        expect(result.errors).to include("Id is not a number")
+      end
+    end
+
+    context "Taskが存在しない場合" do
+      let(:params) { { id: "999999" } }
+
+      before do
+        allow(repository).to receive(:find_by_id_with_lock).with(999999).and_return(nil)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("タスクが見つかりません")
+      end
+    end
+
+    context "正常にサイクルを作成して割り当てが成功した場合" do
+      let(:params) { { id: task.id.to_s } }
+      let(:new_cycle) { instance_double(AssignCycle, id: 100) }
+      let(:assign_result) { instance_double(AssignHistory, account_id: member.id) }
+
+      before do
+        allow(repository).to receive(:find_by_id_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).with(task).and_return(0)
+        allow(repository).to receive(:create_cycle).with(task).and_return(new_cycle)
+        allow(new_cycle).to receive(:assign).and_return(assign_result)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "taskを返すこと" do
+        result = service.call(params, admin)
+        expect(result.task).to eq(task)
+      end
+
+      it "deactivate_all_cyclesを呼び出すこと" do
+        service.call(params, admin)
+        expect(repository).to have_received(:deactivate_all_cycles).with(task)
+      end
+
+      it "create_cycleを呼び出すこと" do
+        service.call(params, admin)
+        expect(repository).to have_received(:create_cycle).with(task)
+      end
+
+      it "assignを呼び出すこと" do
+        service.call(params, admin)
+        expect(new_cycle).to have_received(:assign)
+      end
+    end
+
+    context "サイクルは作成されたが割り当てが失敗した場合" do
+      let(:params) { { id: task.id.to_s } }
+      let(:new_cycle) { instance_double(AssignCycle, id: 100) }
+
+      before do
+        allow(repository).to receive(:find_by_id_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).with(task).and_return(0)
+        allow(repository).to receive(:create_cycle).with(task).and_return(new_cycle)
+        allow(new_cycle).to receive(:assign).and_return(false)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(params, admin)
+        expect(result.errors).to include("割り当て可能なメンバーがいません")
+      end
+
+      it "taskを返すこと（サイクルは作成されているため）" do
+        result = service.call(params, admin)
+        expect(result.task).to eq(task)
+      end
+    end
+
+    context "既存のサイクルがある場合" do
+      let(:params) { { id: task.id.to_s } }
+      let!(:existing_cycle) { create(:assign_cycle, task:, is_active: true) }
+      let(:new_cycle) { instance_double(AssignCycle, id: 100) }
+      let(:assign_result) { instance_double(AssignHistory, account_id: member.id) }
+
+      before do
+        allow(repository).to receive(:find_by_id_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).with(task).and_return(1)
+        allow(repository).to receive(:create_cycle).with(task).and_return(new_cycle)
+        allow(new_cycle).to receive(:assign).and_return(assign_result)
+      end
+
+      it "既存のサイクルを非アクティブ化すること" do
+        service.call(params, admin)
+        expect(repository).to have_received(:deactivate_all_cycles).with(task)
+      end
+    end
+
+    context "Deadlocked例外が発生した場合" do
+      let(:params) { { id: task.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::Deadlocked.new("Deadlock"))
+      end
+
+      it "service_unavailableを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+        expect(result.errors).to include("サーバーが混雑しています")
+      end
+    end
+
+    context "LockWaitTimeout例外が発生した場合" do
+      let(:params) { { id: task.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::LockWaitTimeout.new("Timeout"))
+      end
+
+      it "service_unavailableを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+      end
+    end
+
+    context "RecordInvalid例外が発生した場合" do
+      let(:params) { { id: task.id.to_s } }
+
+      before do
+        allow(repository).to receive(:find_by_id_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).and_raise(ActiveRecord::RecordInvalid.new(task))
+      end
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors).to include("サイクル作成に失敗しました")
+      end
+    end
+  end
+
+  describe "依存性注入" do
+    it "デフォルトでRepositoryを使用すること" do
+      service = described_class.new
+      expect(service.instance_variable_get(:@repository)).to be_a(Services::Tasks::Repository)
+    end
+
+    it "カスタムRepositoryを注入できること" do
+      custom_repo = instance_double(Services::Tasks::Repository)
+      service = described_class.new(repository: custom_repo)
+      expect(service.instance_variable_get(:@repository)).to eq(custom_repo)
+    end
+  end
+end

--- a/spec/services/tasks/create_new_cycle_spec.rb
+++ b/spec/services/tasks/create_new_cycle_spec.rb
@@ -125,9 +125,9 @@ RSpec.describe Services::Tasks::CreateNewCycle, type: :service do
         expect(result.errors).to include("割り当て可能なメンバーがいません")
       end
 
-      it "taskを返すこと（サイクルは作成されているため）" do
+      it "taskがnilであること（トランザクションがロールバックされるため）" do
         result = service.call(params, admin)
-        expect(result.task).to eq(task)
+        expect(result.task).to be_nil
       end
     end
 

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -424,5 +424,13 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       result = repository.create_cycle(task)
       expect(result.task_id).to eq(task.id)
     end
+
+    context "バリデーションエラーが発生した場合" do
+      it "ActiveRecord::RecordInvalidを発生させること" do
+        # task_idがnilの場合など
+        allow(task).to receive_message_chain(:assign_cycles, :create!).and_raise(ActiveRecord::RecordInvalid.new(AssignCycle.new))
+        expect { repository.create_cycle(task) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 end

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -354,4 +354,75 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       end
     end
   end
+
+  describe "#deactivate_all_cycles" do
+    let!(:task) { create(:task, area:) }
+
+    context "アクティブなサイクルがある場合" do
+      let!(:cycle1) { create(:assign_cycle, task:, is_active: true) }
+      let!(:cycle2) { create(:assign_cycle, task:, is_active: true) }
+
+      it "全てのサイクルを非アクティブ化すること" do
+        repository.deactivate_all_cycles(task)
+
+        expect(cycle1.reload.is_active).to be false
+        expect(cycle2.reload.is_active).to be false
+      end
+
+      it "更新された行数を返すこと" do
+        result = repository.deactivate_all_cycles(task)
+        expect(result).to eq(2)
+      end
+    end
+
+    context "サイクルが存在しない場合" do
+      it "エラーにならないこと" do
+        expect { repository.deactivate_all_cycles(task) }.not_to raise_error
+      end
+
+      it "0を返すこと" do
+        result = repository.deactivate_all_cycles(task)
+        expect(result).to eq(0)
+      end
+    end
+
+    context "他のタスクのサイクルがある場合" do
+      let!(:other_task) { create(:task, area:) }
+      let!(:cycle) { create(:assign_cycle, task:, is_active: true) }
+      let!(:other_cycle) { create(:assign_cycle, task: other_task, is_active: true) }
+
+      it "指定タスクのサイクルのみ非アクティブ化すること" do
+        repository.deactivate_all_cycles(task)
+
+        expect(cycle.reload.is_active).to be false
+        expect(other_cycle.reload.is_active).to be true
+      end
+    end
+  end
+
+  describe "#create_cycle" do
+    let!(:task) { create(:task, area:) }
+
+    it "新しいAssignCycleを作成すること" do
+      expect {
+        repository.create_cycle(task)
+      }.to change(AssignCycle, :count).by(1)
+    end
+
+    it "作成されたAssignCycleを返すこと" do
+      result = repository.create_cycle(task)
+      expect(result).to be_a(AssignCycle)
+      expect(result).to be_persisted
+    end
+
+    it "is_activeがtrueで作成されること" do
+      result = repository.create_cycle(task)
+      expect(result.is_active).to be true
+    end
+
+    it "指定したタスクに紐づくこと" do
+      result = repository.create_cycle(task)
+      expect(result.task_id).to eq(task.id)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Tasks#create_new_cycle エンドポイントを4層アーキテクチャへ移行
- 認証・認可（admin_only）を追加
- Contract/Service/Repository 層を実装
- Presenter経由のレスポンス形式に統一

## 変更ファイル

### 新規作成
| ファイル | 目的 |
|---------|------|
| `app/contracts/tasks/create_new_cycle.rb` | 入力検証（id） |
| `spec/contracts/tasks/create_new_cycle_spec.rb` | Contractテスト（21件） |
| `app/services/tasks/create_new_cycle.rb` | 新サイクル作成ユースケース |
| `spec/services/tasks/create_new_cycle_spec.rb` | Serviceテスト（19件） |

### 修正
| ファイル | 変更内容 |
|---------|---------|
| `app/services/tasks/repository.rb` | `deactivate_all_cycles`, `create_cycle` 追加 |
| `spec/services/tasks/repository_spec.rb` | Repositoryテスト追加（9件） |
| `app/controllers/api/tasks_controller.rb` | Service呼び出し、認証追加 |
| `spec/requests/api/tasks_spec.rb` | 認証・認可テスト追加（14件） |
| `docs/todo/TODO.md` | 進捗更新 (17/38 → 45%) |

## 破壊的変更

| 変更 | 影響 |
|-----|------|
| 認証必須化 | フロントエンドは既にトークン送信しているはず |
| 認可追加（admin_only） | 一般メンバーはサイクル作成不可に |
| 割り当て失敗時のレスポンス | `{ status: 422 }` → `{ errors: [...] }` + status 422 |
| 成功時レスポンス | 生task → Presenter経由のフォーマット済みtask |

## Test plan
- [x] Contractテスト（21件）
- [x] Repositoryテスト（9件）
- [x] Serviceテスト（19件）
- [x] Requestテスト（14件）
- [x] 全テストパス（919件）
- [x] RuboCopパス