### PR TITLE
feat: Tasks#unfulfilleds_count 4層アーキテクチャ移行

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -83,6 +83,7 @@ class Api::TasksController < ApplicationController
     if result.success?
       render json: result.count, status: result.status
     else
+      Rails.logger.warn(message: "UnfulfilledsCount failed", errors: result.errors, account_id: @current_account&.id)
       render_error(result.errors, result.status)
     end
   end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed, :ng, :create_new_cycle]
+  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed, :ng, :create_new_cycle, :unfulfilleds_count]
 
   def index
     result = ::Services::Tasks::Index.new.call(index_params, @current_account)
@@ -79,8 +79,12 @@ class Api::TasksController < ApplicationController
   end
 
   def unfulfilleds_count
-    res = AssignCycle.unfulfilleds
-    render json: res.count
+    result = ::Services::Tasks::UnfulfilledsCount.new.call(@current_account)
+    if result.success?
+      render json: result.count, status: result.status
+    else
+      render_error(result.errors, result.status)
+    end
   end
 
   def get_complete_data

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -51,6 +51,11 @@ module Services
         Task.get_ng_tasks
       end
 
+      # 未完了（アクティブ）サイクル数を取得
+      def count_unfulfilleds
+        AssignCycle.unfulfilleds.count
+      end
+
       # タグをIDで取得
       def find_tag(id)
         Tag.find_by(id:)

--- a/app/services/tasks/unfulfilleds_count.rb
+++ b/app/services/tasks/unfulfilleds_count.rb
@@ -2,20 +2,23 @@
 
 module Services
   module Tasks
-    # 未完了タスク数取得
+    # アクティブサイクル数取得
     class UnfulfilledsCount
       def initialize(repository: Repository.new)
         @repository = repository
       end
 
       def call(current_account)
-        # 認証チェック
         return failure(["認証が必要です"], :unauthorized) if current_account.nil?
 
-        # カウント取得
         count = @repository.count_unfulfilleds
-
         success(count)
+      rescue ActiveRecord::ConnectionNotEstablished, PG::ConnectionBad => e
+        log_error("データベース接続失敗", e, current_account)
+        failure(["データベース接続に失敗しました。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::StatementInvalid, ActiveRecord::QueryCanceled => e
+        log_error("データベースクエリ失敗", e, current_account)
+        failure(["データの取得に失敗しました。"], :internal_server_error)
       end
 
       private
@@ -25,6 +28,15 @@ module Services
 
         def failure(errors, status)
           UnfulfilledsCountResult.new(success?: false, count: nil, errors:, status:)
+        end
+
+        def log_error(message, error, account)
+          Rails.logger.error(
+            message:,
+            error_class: error.class.name,
+            error_message: error.message,
+            account_id: account&.id
+          )
         end
     end
 

--- a/app/services/tasks/unfulfilleds_count.rb
+++ b/app/services/tasks/unfulfilleds_count.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    # 未完了タスク数取得
+    class UnfulfilledsCount
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # カウント取得
+        count = @repository.count_unfulfilleds
+
+        success(count)
+      end
+
+      private
+        def success(count)
+          UnfulfilledsCountResult.new(success?: true, count:, errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          UnfulfilledsCountResult.new(success?: false, count: nil, errors:, status:)
+        end
+    end
+
+    # UnfulfilledsCount専用Result
+    UnfulfilledsCountResult = Struct.new(:success?, :count, :errors, :status, keyword_init: true)
+  end
+end

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -24,7 +24,7 @@ Controller → Contract → Service → Repository → Model
 |--------------|---------|-------|------|
 | Accounts | 6/6 | 0 | ✅ 完了 |
 | Authentications | 1/1 | 0 | ✅ 完了 |
-| Tasks | 10/12 | 2 | 🔶 進行中 |
+| Tasks | 11/12 | 1 | 🔶 進行中 |
 | Areas | 0/5 | 5 | ⬜ 未着手 |
 | Comments | 0/5 | 5 | ⬜ 未着手 |
 | Tags | 0/4 | 4 | ⬜ 未着手 |
@@ -32,7 +32,7 @@ Controller → Contract → Service → Repository → Model
 | AccountAreas | 0/2 | 2 | ⬜ 未着手 |
 | TagAccounts | 0/2 | 2 | ⬜ 未着手 |
 
-**合計: 17/38 (45%)**
+**合計: 18/38 (47%)**
 
 ---
 
@@ -89,11 +89,13 @@ Controller → Contract → Service → Repository → Model
   - Presenter: `TaskPresenter.render_task`（既存）
   - 認証必須化、認可追加（admin_only）
 
-### 未移行
-
-- [ ] `GET /api/unfulfilled-count` (unfulfilleds_count)
+- [x] `GET /api/unfulfilled-count` (unfulfilleds_count)
   - Service: `Services::Tasks::UnfulfilledsCount`
+  - Repository: `count_unfulfilleds`追加
   - Note: Contractなし（パラメータなし）
+  - 認証必須化
+
+### 未移行
 
 - [ ] `GET /api/completed-data` (get_complete_data)
   - Service: `Services::Tasks::GetCompleteData`
@@ -208,6 +210,7 @@ Controller → Contract → Service → Repository → Model
 | `PUT /api/tasks/:id` | 認証必須化、認可追加(admin+担当者)、`is_complete`削除、Presenter経由レスポンス | - |
 | `DELETE /api/tasks/:id` | 認証必須化、認可追加(admin_only)、レスポンス: 204→200+message | - |
 | `PUT /api/tasks/:id/ng` | 認証必須化、認可追加(admin+担当者)、errors追加 | - |
+| `GET /api/unfulfilled-count` | 認証必須化 | - |
 
 ---
 

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -983,21 +983,84 @@ RSpec.describe Api::TasksController, type: :controller do
 
   describe "GET #unfulfilleds_count" do
     before do
+      @admin = create(:account)
       @member = create(:account_member)
       @area = create(:area)
       @task = create(:task, area_id: @area.id)
-      @cycle = create(:assign_cycle, task_id: @task.id)
+      @cycle = create(:assign_cycle, task_id: @task.id, is_active: true)
     end
 
-    it "Status 200が返ってくること" do
-      get :unfulfilleds_count
-      expect(response).to have_http_status(:ok)
+    context "認証なしの場合" do
+      before do
+        request.headers["Authorization"] = nil
+      end
+
+      it "Status 401が返ること" do
+        get :unfulfilleds_count
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "エラーメッセージが返ること" do
+        get :unfulfilleds_count
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("unauthorized")
+      end
     end
 
-    it "数値が返ってくること" do
-      get :unfulfilleds_count
-      json_response = JSON.parse(response.body)
-      expect(json_response).to be_a(Integer)
+    context "管理者で認証されている場合" do
+      before do
+        token = JsonWebToken.encode(account_id: @admin.id)
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 200が返ってくること" do
+        get :unfulfilleds_count
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "数値が返ってくること" do
+        get :unfulfilleds_count
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_a(Integer)
+      end
+
+      it "アクティブサイクル数が返ること" do
+        get :unfulfilleds_count
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq(1)
+      end
+    end
+
+    context "一般メンバーで認証されている場合" do
+      before do
+        token = JsonWebToken.encode(account_id: @member.id)
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 200が返ってくること（認可なし）" do
+        get :unfulfilleds_count
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "数値が返ってくること" do
+        get :unfulfilleds_count
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_a(Integer)
+      end
+    end
+
+    context "アクティブサイクルがない場合" do
+      before do
+        @cycle.update!(is_active: false)
+        token = JsonWebToken.encode(account_id: @admin.id)
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "0が返ること" do
+        get :unfulfilleds_count
+        json_response = JSON.parse(response.body)
+        expect(json_response).to eq(0)
+      end
     end
   end
 

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -463,5 +463,17 @@ RSpec.describe Services::Tasks::Repository, type: :service do
         expect(result).to eq(1)
       end
     end
+
+    context "複数タスクにアクティブサイクルがある場合" do
+      let!(:task2) { create(:task, area:) }
+      let!(:cycle1) { create(:assign_cycle, task:, is_active: true) }
+      let!(:cycle2) { create(:assign_cycle, task: task2, is_active: true) }
+      let!(:cycle3) { create(:assign_cycle, task: task2, is_active: false) }
+
+      it "全タスクのアクティブサイクル合計を返すこと" do
+        result = repository.count_unfulfilleds
+        expect(result).to eq(2)
+      end
+    end
   end
 end

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -433,4 +433,35 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       end
     end
   end
+
+  describe "#count_unfulfilleds" do
+    let!(:task) { create(:task, area:) }
+
+    context "アクティブなサイクルがある場合" do
+      let!(:cycle1) { create(:assign_cycle, task:, is_active: true) }
+      let!(:cycle2) { create(:assign_cycle, task:, is_active: true) }
+
+      it "アクティブサイクル数を返すこと" do
+        result = repository.count_unfulfilleds
+        expect(result).to eq(2)
+      end
+    end
+
+    context "アクティブなサイクルがない場合" do
+      it "0を返すこと" do
+        result = repository.count_unfulfilleds
+        expect(result).to eq(0)
+      end
+    end
+
+    context "非アクティブなサイクルがある場合" do
+      let!(:active_cycle) { create(:assign_cycle, task:, is_active: true) }
+      let!(:inactive_cycle) { create(:assign_cycle, task:, is_active: false) }
+
+      it "アクティブサイクルのみカウントすること" do
+        result = repository.count_unfulfilleds
+        expect(result).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/services/tasks/unfulfilleds_count_spec.rb
+++ b/spec/services/tasks/unfulfilleds_count_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::UnfulfilledsCount, type: :service do
+  let(:repository) { instance_double(Services::Tasks::Repository) }
+  let(:service) { described_class.new(repository:) }
+
+  describe "#call" do
+    let!(:admin) { create(:account) }
+    let!(:member) { create(:account_member) }
+
+    context "認証されていない場合" do
+      it "unauthorizedを返すこと" do
+        result = service.call(nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unauthorized)
+        expect(result.errors).to include("認証が必要です")
+      end
+
+      it "countがnilであること" do
+        result = service.call(nil)
+        expect(result.count).to be_nil
+      end
+    end
+
+    context "管理者で認証されている場合" do
+      before do
+        allow(repository).to receive(:count_unfulfilleds).and_return(5)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "カウントを返すこと" do
+        result = service.call(admin)
+        expect(result.count).to eq(5)
+      end
+
+      it "repository.count_unfulfilledsを呼び出すこと" do
+        service.call(admin)
+        expect(repository).to have_received(:count_unfulfilleds)
+      end
+    end
+
+    context "一般メンバーで認証されている場合" do
+      before do
+        allow(repository).to receive(:count_unfulfilleds).and_return(3)
+      end
+
+      it "成功を返すこと（認可なし - 読み取り専用）" do
+        result = service.call(member)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "カウントを返すこと" do
+        result = service.call(member)
+        expect(result.count).to eq(3)
+      end
+    end
+
+    context "カウントが0の場合" do
+      before do
+        allow(repository).to receive(:count_unfulfilleds).and_return(0)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be true
+      end
+
+      it "0を返すこと" do
+        result = service.call(admin)
+        expect(result.count).to eq(0)
+      end
+    end
+  end
+
+  describe "依存性注入" do
+    it "デフォルトでRepositoryを使用すること" do
+      service = described_class.new
+      expect(service.instance_variable_get(:@repository)).to be_a(Services::Tasks::Repository)
+    end
+
+    it "カスタムRepositoryを注入できること" do
+      custom_repo = instance_double(Services::Tasks::Repository)
+      service = described_class.new(repository: custom_repo)
+      expect(service.instance_variable_get(:@repository)).to eq(custom_repo)
+    end
+  end
+end

--- a/spec/services/tasks/unfulfilleds_count_spec.rb
+++ b/spec/services/tasks/unfulfilleds_count_spec.rb
@@ -78,6 +78,52 @@ RSpec.describe Services::Tasks::UnfulfilledsCount, type: :service do
         expect(result.count).to eq(0)
       end
     end
+
+    context "データベース接続エラーの場合" do
+      before do
+        allow(repository).to receive(:count_unfulfilleds).and_raise(ActiveRecord::ConnectionNotEstablished)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(admin)
+        expect(result.errors).to include("データベース接続に失敗しました。しばらくしてから再試行してください。")
+      end
+
+      it "エラーをログに記録すること" do
+        service.call(admin)
+        expect(Rails.logger).to have_received(:error).with(hash_including(message: "データベース接続失敗"))
+      end
+    end
+
+    context "データベースクエリエラーの場合" do
+      before do
+        allow(repository).to receive(:count_unfulfilleds).and_raise(ActiveRecord::StatementInvalid.new("query error"))
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(admin)
+        expect(result.errors).to include("データの取得に失敗しました。")
+      end
+
+      it "エラーをログに記録すること" do
+        service.call(admin)
+        expect(Rails.logger).to have_received(:error).with(hash_including(message: "データベースクエリ失敗"))
+      end
+    end
   end
 
   describe "依存性注入" do


### PR DESCRIPTION
## Summary
- `GET /api/unfulfilled-count` エンドポイントを4層アーキテクチャに移行
- `Services::Tasks::UnfulfilledsCount` を新規作成
- 認証を必須化（破壊的変更）

## 変更内容
- 新規: `app/services/tasks/unfulfilleds_count.rb`
- 新規: `spec/services/tasks/unfulfilleds_count_spec.rb`
- 修正: `app/services/tasks/repository.rb` - `count_unfulfilleds` メソッド追加
- 修正: `app/controllers/api/tasks_controller.rb` - Service経由に書き換え
- 修正: Request specに認証テスト追加

## 破壊的変更
- 未認証リクエストは401エラーを返すように変更

## Test plan
- [x] Repository テスト (3件追加)
- [x] Service テスト (11件)
- [x] Request テスト (8件、認証テスト含む)
- [x] RuboCop Pass
- [x] 全テスト Pass (940件)