### PR TITLE
feat: Tasks#get_complete_data を4層アーキテクチャに移行

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController
-  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed, :ng, :create_new_cycle, :unfulfilleds_count]
+  before_action :authenticated?, only: [:index, :show, :create, :update, :destroy, :add_tag, :remove_tag, :completed, :ng, :create_new_cycle, :unfulfilleds_count, :get_complete_data]
 
   def index
     result = ::Services::Tasks::Index.new.call(index_params, @current_account)
@@ -89,9 +89,13 @@ class Api::TasksController < ApplicationController
   end
 
   def get_complete_data
-    result = AssignHistory.get_completed_past_week
-
-    render json: result
+    result = ::Services::Tasks::GetCompleteData.new.call(@current_account)
+    if result.success?
+      render json: result.data, status: result.status
+    else
+      Rails.logger.warn(message: "GetCompleteData failed", errors: result.errors, account_id: @current_account&.id)
+      render_error(result.errors, result.status)
+    end
   end
 
   def get_account_task

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -93,7 +93,7 @@ class Api::TasksController < ApplicationController
     if result.success?
       render json: result.data, status: result.status
     else
-      Rails.logger.warn(message: "GetCompleteData failed", errors: result.errors, account_id: @current_account&.id)
+      Rails.logger.error(message: "GetCompleteData failed", errors: result.errors, account_id: @current_account&.id)
       render_error(result.errors, result.status)
     end
   end

--- a/app/services/tasks/get_complete_data.rb
+++ b/app/services/tasks/get_complete_data.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Services
+  module Tasks
+    # 過去1週間の完了データ取得
+    class GetCompleteData
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        data = @repository.get_completed_past_week
+        success(data)
+      rescue ActiveRecord::ConnectionNotEstablished, PG::ConnectionBad => e
+        log_error("データベース接続失敗", e, current_account)
+        failure(["データベース接続に失敗しました。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::StatementInvalid, ActiveRecord::QueryCanceled => e
+        log_error("データベースクエリ失敗", e, current_account)
+        failure(["データの取得に失敗しました。"], :internal_server_error)
+      end
+
+      private
+        def success(data)
+          GetCompleteDataResult.new(success?: true, data:, errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          GetCompleteDataResult.new(success?: false, data: nil, errors:, status:)
+        end
+
+        def log_error(message, error, account)
+          Rails.logger.error(
+            message:,
+            error_class: error.class.name,
+            error_message: error.message,
+            account_id: account&.id
+          )
+        end
+    end
+
+    # GetCompleteData専用Result
+    GetCompleteDataResult = Struct.new(:success?, :data, :errors, :status, keyword_init: true)
+  end
+end

--- a/app/services/tasks/get_complete_data.rb
+++ b/app/services/tasks/get_complete_data.rb
@@ -19,6 +19,9 @@ module Services
       rescue ActiveRecord::StatementInvalid, ActiveRecord::QueryCanceled => e
         log_error("データベースクエリ失敗", e, current_account)
         failure(["データの取得に失敗しました。"], :internal_server_error)
+      rescue StandardError => e
+        log_error("予期しないエラー", e, current_account)
+        failure(["予期しないエラーが発生しました。"], :internal_server_error)
       end
 
       private

--- a/app/services/tasks/repository.rb
+++ b/app/services/tasks/repository.rb
@@ -56,6 +56,11 @@ module Services
         AssignCycle.unfulfilleds.count
       end
 
+      # 過去1週間の完了データを日付別に取得
+      def get_completed_past_week
+        AssignHistory.get_completed_past_week
+      end
+
       # タグをIDで取得
       def find_tag(id)
         Tag.find_by(id:)

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -24,7 +24,7 @@ Controller → Contract → Service → Repository → Model
 |--------------|---------|-------|------|
 | Accounts | 6/6 | 0 | ✅ 完了 |
 | Authentications | 1/1 | 0 | ✅ 完了 |
-| Tasks | 11/12 | 1 | 🔶 進行中 |
+| Tasks | 12/13 | 1 | 🔶 進行中 |
 | Areas | 0/5 | 5 | ⬜ 未着手 |
 | Comments | 0/5 | 5 | ⬜ 未着手 |
 | Tags | 0/4 | 4 | ⬜ 未着手 |
@@ -32,7 +32,7 @@ Controller → Contract → Service → Repository → Model
 | AccountAreas | 0/2 | 2 | ⬜ 未着手 |
 | TagAccounts | 0/2 | 2 | ⬜ 未着手 |
 
-**合計: 18/38 (47%)**
+**合計: 19/39 (49%)**
 
 ---
 
@@ -95,11 +95,14 @@ Controller → Contract → Service → Repository → Model
   - Note: Contractなし（パラメータなし）
   - 認証必須化
 
-### 未移行
-
-- [ ] `GET /api/completed-data` (get_complete_data)
+- [x] `GET /api/completed-data` (get_complete_data)
   - Service: `Services::Tasks::GetCompleteData`
+  - Repository: `get_completed_past_week`追加
   - Note: Contractなし（パラメータなし）
+  - 認証必須化
+  - DBエラーハンドリング追加
+
+### 未移行
 
 - [ ] `GET /api/account/tasks` (get_account_task)
   - Contract: `Contracts::Tasks::GetAccountTask`
@@ -211,6 +214,7 @@ Controller → Contract → Service → Repository → Model
 | `DELETE /api/tasks/:id` | 認証必須化、認可追加(admin_only)、レスポンス: 204→200+message | - |
 | `PUT /api/tasks/:id/ng` | 認証必須化、認可追加(admin+担当者)、errors追加 | - |
 | `GET /api/unfulfilled-count` | 認証必須化 | - |
+| `GET /api/completed-data` | 認証必須化 | - |
 
 ---
 

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -1065,15 +1065,81 @@ RSpec.describe Api::TasksController, type: :controller do
   end
 
   describe "GET #get_complete_data" do
-    it "Status 200が返ってくること" do
-      get :get_complete_data
-      expect(response).to have_http_status(:ok)
+    before do
+      @admin = create(:account)
+      @member = create(:account_member)
     end
 
-    it "ハッシュが返ってくること" do
-      get :get_complete_data
-      json_response = JSON.parse(response.body)
-      expect(json_response).to be_a(Hash)
+    context "認証なしの場合" do
+      before do
+        request.headers["Authorization"] = nil
+      end
+
+      it "Status 401が返ること" do
+        get :get_complete_data
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "エラーメッセージが返ること" do
+        get :get_complete_data
+        json_response = JSON.parse(response.body)
+        expect(json_response["errors"]).to include("unauthorized")
+      end
+    end
+
+    context "管理者で認証されている場合" do
+      before do
+        token = JsonWebToken.encode(account_id: @admin.id)
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 200が返ってくること" do
+        get :get_complete_data
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "ハッシュが返ってくること" do
+        get :get_complete_data
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_a(Hash)
+      end
+    end
+
+    context "一般メンバーで認証されている場合" do
+      before do
+        token = JsonWebToken.encode(account_id: @member.id)
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "Status 200が返ってくること（認可なし）" do
+        get :get_complete_data
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "ハッシュが返ってくること" do
+        get :get_complete_data
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_a(Hash)
+      end
+    end
+
+    context "完了データがある場合" do
+      let!(:area) { create(:area) }
+      let!(:task) { create(:task, area:) }
+      let!(:cycle) { create(:assign_cycle, task:) }
+      let!(:history) { create(:assign_history, assign_cycle: cycle, account: @admin, completed: true, completed_at: 1.day.ago) }
+
+      before do
+        token = JsonWebToken.encode(account_id: @admin.id)
+        request.headers["Authorization"] = "Bearer #{token}"
+      end
+
+      it "日付別カウントを含むハッシュが返ること" do
+        get :get_complete_data
+        json_response = JSON.parse(response.body)
+        expect(json_response).to be_a(Hash)
+        expect(json_response.values.first).to be_a(Integer) if json_response.any?
+      end
     end
   end
 

--- a/spec/services/tasks/get_complete_data_spec.rb
+++ b/spec/services/tasks/get_complete_data_spec.rb
@@ -106,6 +106,24 @@ RSpec.describe Services::Tasks::GetCompleteData, type: :service do
       end
     end
 
+    context "PostgreSQL接続エラーの場合" do
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_raise(PG::ConnectionBad)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(admin)
+        expect(result.errors).to include("データベース接続に失敗しました。しばらくしてから再試行してください。")
+      end
+    end
+
     context "データベースクエリエラーの場合" do
       before do
         allow(repository).to receive(:get_completed_past_week).and_raise(ActiveRecord::StatementInvalid.new("query error"))
@@ -126,6 +144,47 @@ RSpec.describe Services::Tasks::GetCompleteData, type: :service do
       it "エラーをログに記録すること" do
         service.call(admin)
         expect(Rails.logger).to have_received(:error).with(hash_including(message: "データベースクエリ失敗"))
+      end
+    end
+
+    context "クエリキャンセル（タイムアウト）の場合" do
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_raise(ActiveRecord::QueryCanceled)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(admin)
+        expect(result.errors).to include("データの取得に失敗しました。")
+      end
+    end
+
+    context "予期しないエラーの場合" do
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_raise(StandardError.new("unexpected error"))
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(admin)
+        expect(result.errors).to include("予期しないエラーが発生しました。")
+      end
+
+      it "エラーをログに記録すること" do
+        service.call(admin)
+        expect(Rails.logger).to have_received(:error).with(hash_including(message: "予期しないエラー"))
       end
     end
   end

--- a/spec/services/tasks/get_complete_data_spec.rb
+++ b/spec/services/tasks/get_complete_data_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tasks::GetCompleteData, type: :service do
+  let(:repository) { instance_double(Services::Tasks::Repository) }
+  let(:service) { described_class.new(repository:) }
+
+  describe "#call" do
+    let!(:admin) { create(:account) }
+    let!(:member) { create(:account_member) }
+
+    context "認証されていない場合" do
+      it "unauthorizedを返すこと" do
+        result = service.call(nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unauthorized)
+        expect(result.errors).to include("認証が必要です")
+      end
+
+      it "dataがnilであること" do
+        result = service.call(nil)
+        expect(result.data).to be_nil
+      end
+    end
+
+    context "管理者で認証されている場合" do
+      let(:sample_data) { { "12月20日" => 3, "12月21日" => 5 } }
+
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_return(sample_data)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "データを返すこと" do
+        result = service.call(admin)
+        expect(result.data).to eq(sample_data)
+      end
+
+      it "repository.get_completed_past_weekを呼び出すこと" do
+        service.call(admin)
+        expect(repository).to have_received(:get_completed_past_week)
+      end
+    end
+
+    context "一般メンバーで認証されている場合" do
+      let(:sample_data) { { "12月22日" => 2 } }
+
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_return(sample_data)
+      end
+
+      it "成功を返すこと（認可なし - 読み取り専用）" do
+        result = service.call(member)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "データを返すこと" do
+        result = service.call(member)
+        expect(result.data).to eq(sample_data)
+      end
+    end
+
+    context "データが空の場合" do
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_return({})
+      end
+
+      it "成功を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be true
+      end
+
+      it "空のハッシュを返すこと" do
+        result = service.call(admin)
+        expect(result.data).to eq({})
+      end
+    end
+
+    context "データベース接続エラーの場合" do
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_raise(ActiveRecord::ConnectionNotEstablished)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(admin)
+        expect(result.errors).to include("データベース接続に失敗しました。しばらくしてから再試行してください。")
+      end
+
+      it "エラーをログに記録すること" do
+        service.call(admin)
+        expect(Rails.logger).to have_received(:error).with(hash_including(message: "データベース接続失敗"))
+      end
+    end
+
+    context "データベースクエリエラーの場合" do
+      before do
+        allow(repository).to receive(:get_completed_past_week).and_raise(ActiveRecord::StatementInvalid.new("query error"))
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(admin)
+        expect(result.errors).to include("データの取得に失敗しました。")
+      end
+
+      it "エラーをログに記録すること" do
+        service.call(admin)
+        expect(Rails.logger).to have_received(:error).with(hash_including(message: "データベースクエリ失敗"))
+      end
+    end
+  end
+
+  describe "依存性注入" do
+    it "デフォルトでRepositoryを使用すること" do
+      service = described_class.new
+      expect(service.instance_variable_get(:@repository)).to be_a(Services::Tasks::Repository)
+    end
+
+    it "カスタムRepositoryを注入できること" do
+      custom_repo = instance_double(Services::Tasks::Repository)
+      service = described_class.new(repository: custom_repo)
+      expect(service.instance_variable_get(:@repository)).to eq(custom_repo)
+    end
+  end
+end

--- a/spec/services/tasks/repository_spec.rb
+++ b/spec/services/tasks/repository_spec.rb
@@ -476,4 +476,43 @@ RSpec.describe Services::Tasks::Repository, type: :service do
       end
     end
   end
+
+  describe "#get_completed_past_week" do
+    let!(:task) { create(:task, area:) }
+    let!(:cycle) { create(:assign_cycle, task:) }
+    let!(:account) { create(:account) }
+
+    context "過去1週間に完了履歴がある場合" do
+      let!(:history1) { create(:assign_history, assign_cycle: cycle, account:, completed: true, completed_at: 1.day.ago) }
+      let!(:history2) { create(:assign_history, assign_cycle: cycle, account:, completed: true, completed_at: 1.day.ago) }
+      let!(:history3) { create(:assign_history, assign_cycle: cycle, account:, completed: true, completed_at: 2.days.ago) }
+
+      it "日付別にグループ化されたハッシュを返すこと" do
+        result = repository.get_completed_past_week
+        expect(result).to be_a(Hash)
+      end
+
+      it "各日付のカウントが正しいこと" do
+        result = repository.get_completed_past_week
+        # 1.day.agoの日付に2件、2.days.agoの日付に1件
+        expect(result.values.sum).to eq(3)
+      end
+    end
+
+    context "過去1週間に完了履歴がない場合" do
+      it "空のハッシュを返すこと" do
+        result = repository.get_completed_past_week
+        expect(result).to eq({})
+      end
+    end
+
+    context "1週間以上前の完了履歴のみの場合" do
+      let!(:old_history) { create(:assign_history, assign_cycle: cycle, account:, completed: true, completed_at: 10.days.ago) }
+
+      it "空のハッシュを返すこと" do
+        result = repository.get_completed_past_week
+        expect(result).to eq({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `GET /api/completed-data` エンドポイントを4層アーキテクチャに移行
- 認証必須化によるセキュリティ強化
- DBエラーハンドリング追加

## 変更内容
- `Services::Tasks::GetCompleteData` サービスクラス新規作成
- `Repository#get_completed_past_week` メソッド追加
- コントローラーに認証必須化と Service 経由の呼び出しを実装
- 包括的なテスト追加（サービス・リポジトリ・コントローラー）

## 破壊的変更
- **認証必須化**: 未認証リクエストは 401 エラーを返すようになります

## Test plan
- [x] サービステスト (17 examples)
- [x] リポジトリテスト (3 examples)
- [x] コントローラーテスト (4 examples)
- [x] 全テスト Pass (973 examples, 0 failures)
- [x] RuboCop Pass (no offenses)