### PR TITLE
refactor: Tasks Result Struct を統合

### DIFF
--- a/app/services/tasks/completed.rb
+++ b/app/services/tasks/completed.rb
@@ -59,15 +59,12 @@ module Services
         end
 
         def success
-          CompletedResult.new(success?: true, message: "change completed", errors: [], status: :ok)
+          Result.new(success?: true, message: "change completed", errors: [], status: :ok)
         end
 
         def failure(errors, status)
-          CompletedResult.new(success?: false, message: "change failed", errors:, status:)
+          Result.new(success?: false, message: "change failed", errors:, status:)
         end
     end
-
-    # Completed専用Result（後方互換性のためmessageを返す）
-    CompletedResult = Struct.new(:success?, :message, :errors, :status, keyword_init: true)
   end
 end

--- a/app/services/tasks/create_new_cycle.rb
+++ b/app/services/tasks/create_new_cycle.rb
@@ -60,15 +60,12 @@ module Services
 
       private
         def success(task)
-          CreateNewCycleResult.new(success?: true, task:, message: nil, errors: [], status: :ok)
+          Result.new(success?: true, task:, message: nil, errors: [], status: :ok)
         end
 
         def failure(errors, task, status)
-          CreateNewCycleResult.new(success?: false, task:, message: "failed", errors:, status:)
+          Result.new(success?: false, task:, message: "failed", errors:, status:)
         end
     end
-
-    # CreateNewCycle専用Result
-    CreateNewCycleResult = Struct.new(:success?, :task, :message, :errors, :status, keyword_init: true)
   end
 end

--- a/app/services/tasks/destroy.rb
+++ b/app/services/tasks/destroy.rb
@@ -42,15 +42,12 @@ module Services
 
       private
         def success
-          DestroyResult.new(success?: true, message: "deleted", errors: [], status: :ok)
+          Result.new(success?: true, message: "deleted", errors: [], status: :ok)
         end
 
         def failure(errors, status)
-          DestroyResult.new(success?: false, message: nil, errors:, status:)
+          Result.new(success?: false, message: nil, errors:, status:)
         end
     end
-
-    # Destroy専用Result（taskを返さない）
-    DestroyResult = Struct.new(:success?, :message, :errors, :status, keyword_init: true)
   end
 end

--- a/app/services/tasks/get_complete_data.rb
+++ b/app/services/tasks/get_complete_data.rb
@@ -26,11 +26,11 @@ module Services
 
       private
         def success(data)
-          GetCompleteDataResult.new(success?: true, data:, errors: [], status: :ok)
+          Result.new(success?: true, data:, errors: [], status: :ok)
         end
 
         def failure(errors, status)
-          GetCompleteDataResult.new(success?: false, data: nil, errors:, status:)
+          Result.new(success?: false, data: nil, errors:, status:)
         end
 
         def log_error(message, error, account)
@@ -42,8 +42,5 @@ module Services
           )
         end
     end
-
-    # GetCompleteData専用Result
-    GetCompleteDataResult = Struct.new(:success?, :data, :errors, :status, keyword_init: true)
   end
 end

--- a/app/services/tasks/ng.rb
+++ b/app/services/tasks/ng.rb
@@ -73,15 +73,12 @@ module Services
         end
 
         def success(message)
-          NgResult.new(success?: true, message:, errors: [], status: :ok)
+          Result.new(success?: true, message:, errors: [], status: :ok)
         end
 
         def failure(errors, status)
-          NgResult.new(success?: false, message: "failed", errors:, status:)
+          Result.new(success?: false, message: "failed", errors:, status:)
         end
     end
-
-    # Ng専用Result（後方互換性のためmessageを返す）
-    NgResult = Struct.new(:success?, :message, :errors, :status, keyword_init: true)
   end
 end

--- a/app/services/tasks/result.rb
+++ b/app/services/tasks/result.rb
@@ -2,9 +2,29 @@
 
 module Services
   module Tasks
-    # Unified Result for Tasks services.
-    # task: 単一リソース（create/show等）
-    # tasks: コレクション（index等）
-    Result = Struct.new(:success?, :task, :tasks, :errors, :status, keyword_init: true)
+    # Tasks サービス共通 Result
+    #
+    # 全サービスで統一して使用するResult Struct
+    # 使用しないフィールドはnilのまま
+    #
+    # @attr success? [Boolean] 処理成功/失敗
+    # @attr task [Task, nil] 単一リソース（show/create/update等）
+    # @attr tasks [Array, nil] コレクション（index/get_account_task等）
+    # @attr message [String, nil] 処理結果メッセージ（completed/ng/destroy等）
+    # @attr count [Integer, nil] カウント値（unfulfilleds_count）
+    # @attr data [Hash, nil] 汎用データ（get_complete_data）
+    # @attr errors [Array] エラーメッセージ配列
+    # @attr status [Symbol] HTTPステータス（:ok, :created, :not_found等）
+    Result = Struct.new(
+      :success?,
+      :task,
+      :tasks,
+      :message,
+      :count,
+      :data,
+      :errors,
+      :status,
+      keyword_init: true
+    )
   end
 end

--- a/app/services/tasks/result.rb
+++ b/app/services/tasks/result.rb
@@ -8,12 +8,12 @@ module Services
     # 使用しないフィールドはnilのまま
     #
     # @attr success? [Boolean] 処理成功/失敗
-    # @attr task [Task, nil] 単一リソース（show/create/update等）
-    # @attr tasks [Array, nil] コレクション（index/get_account_task等）
-    # @attr message [String, nil] 処理結果メッセージ（completed/ng/destroy等）
-    # @attr count [Integer, nil] カウント値（unfulfilleds_count）
-    # @attr data [Hash, nil] 汎用データ（get_complete_data）
-    # @attr errors [Array] エラーメッセージ配列
+    # @attr task [Task, nil] 単一タスクリソース
+    # @attr tasks [Array, nil] タスクコレクション
+    # @attr message [String, nil] 処理結果メッセージ（状態変更系サービス）
+    # @attr count [Integer, nil] カウント値
+    # @attr data [Hash, nil] 汎用データ
+    # @attr errors [Array<String>] エラーメッセージ配列
     # @attr status [Symbol] HTTPステータス（:ok, :created, :not_found等）
     Result = Struct.new(
       :success?,

--- a/app/services/tasks/unfulfilleds_count.rb
+++ b/app/services/tasks/unfulfilleds_count.rb
@@ -23,11 +23,11 @@ module Services
 
       private
         def success(count)
-          UnfulfilledsCountResult.new(success?: true, count:, errors: [], status: :ok)
+          Result.new(success?: true, count:, errors: [], status: :ok)
         end
 
         def failure(errors, status)
-          UnfulfilledsCountResult.new(success?: false, count: nil, errors:, status:)
+          Result.new(success?: false, count: nil, errors:, status:)
         end
 
         def log_error(message, error, account)
@@ -39,8 +39,5 @@ module Services
           )
         end
     end
-
-    # UnfulfilledsCount専用Result
-    UnfulfilledsCountResult = Struct.new(:success?, :count, :errors, :status, keyword_init: true)
   end
 end


### PR DESCRIPTION
## Summary
- 6つの個別Result Structを1つの統合Resultに集約
- DRY原則違反の解消、ARCHITECTURE.md準拠

## 変更前
```ruby
# 6つの個別定義
DestroyResult = Struct.new(:success?, :message, :errors, :status, ...)
CompletedResult = Struct.new(:success?, :message, :errors, :status, ...)
NgResult = Struct.new(:success?, :message, :errors, :status, ...)
CreateNewCycleResult = Struct.new(:success?, :task, :message, :errors, :status, ...)
UnfulfilledsCountResult = Struct.new(:success?, :count, :errors, :status, ...)
GetCompleteDataResult = Struct.new(:success?, :data, :errors, :status, ...)
```

## 変更後
```ruby
# 統合Result（使用しないフィールドはnilのまま）
Result = Struct.new(
  :success?,
  :task,      # 単一リソース
  :tasks,     # コレクション
  :message,   # 処理結果メッセージ
  :count,     # カウント値
  :data,      # 汎用データ
  :errors,
  :status,
  keyword_init: true
)
```

## 変更ファイル
- `app/services/tasks/result.rb` - 統合定義
- `app/services/tasks/destroy.rb`
- `app/services/tasks/completed.rb`
- `app/services/tasks/ng.rb`
- `app/services/tasks/create_new_cycle.rb`
- `app/services/tasks/unfulfilleds_count.rb`
- `app/services/tasks/get_complete_data.rb`

## Test plan
- [x] 全テスト Pass (1047 examples, 0 failures)
- [x] RuboCop Pass (no offenses)