### PR TITLE
refactor: Areas コントローラーを4層アーキテクチャに移行

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,7 @@ AllCops:
     - '**/4_*_release_notes.md'
     - '**/5_*_release_notes.md'
     - '**/6_*_release_notes.md'
+    - '*.md'
 
 
 Performance:

--- a/app/contracts/areas/create.rb
+++ b/app/contracts/areas/create.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Areas
+    class Create
+      include ActiveModel::Model
+
+      attr_accessor :name
+
+      validates :name, presence: true, length: { maximum: 32 }
+
+      def self.call(params)
+        contract = new(name: params.dig(:area, :name) || params[:name])
+
+        if contract.valid?
+          Result.new(success?: true, value: { name: contract.name }, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+    end
+  end
+end

--- a/app/contracts/areas/create.rb
+++ b/app/contracts/areas/create.rb
@@ -13,9 +13,9 @@ module Contracts
         contract = new(name: params.dig(:area, :name) || params[:name])
 
         if contract.valid?
-          Result.new(success?: true, value: { name: contract.name }, errors: [])
+          Contracts::Result.new(success?: true, value: { name: contract.name }, errors: [])
         else
-          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
         end
       end
     end

--- a/app/contracts/areas/create.rb
+++ b/app/contracts/areas/create.rb
@@ -2,6 +2,13 @@
 
 module Contracts
   module Areas
+    # エリア作成用コントラクト
+    #
+    # 検証ルール:
+    # - name: 必須、最大32文字
+    #
+    # パラメータ形式:
+    # - { name: "..." } または { area: { name: "..." } }
     class Create
       include ActiveModel::Model
 

--- a/app/contracts/areas/destroy.rb
+++ b/app/contracts/areas/destroy.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Areas
+    class Destroy < IdContract
+    end
+  end
+end

--- a/app/contracts/areas/id_contract.rb
+++ b/app/contracts/areas/id_contract.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Areas
+    class IdContract
+      include ActiveModel::Model
+
+      attr_accessor :id
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+
+      def self.call(params)
+        contract = new(id: params[:id])
+
+        if contract.valid?
+          Result.new(success?: true, value: { id: contract.id.to_i }, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+    end
+  end
+end

--- a/app/contracts/areas/id_contract.rb
+++ b/app/contracts/areas/id_contract.rb
@@ -14,9 +14,9 @@ module Contracts
         contract = new(id: params[:id])
 
         if contract.valid?
-          Result.new(success?: true, value: { id: contract.id.to_i }, errors: [])
+          Contracts::Result.new(success?: true, value: { id: contract.id.to_i }, errors: [])
         else
-          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
         end
       end
     end

--- a/app/contracts/areas/id_contract.rb
+++ b/app/contracts/areas/id_contract.rb
@@ -2,6 +2,12 @@
 
 module Contracts
   module Areas
+    # エリアID検証用の基底コントラクト
+    #
+    # 検証ルール:
+    # - id: 必須、正の整数のみ
+    #
+    # Show, Destroy コントラクトの親クラスとして使用
     class IdContract
       include ActiveModel::Model
 

--- a/app/contracts/areas/show.rb
+++ b/app/contracts/areas/show.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Areas
+    class Show < IdContract
+    end
+  end
+end

--- a/app/contracts/areas/update.rb
+++ b/app/contracts/areas/update.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Areas
+    class Update
+      include ActiveModel::Model
+
+      attr_accessor :id, :name
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+      validates :name, length: { maximum: 32 }, allow_nil: true
+
+      def self.call(params)
+        contract = new(
+          id: params[:id],
+          name: params.dig(:area, :name) || params[:name]
+        )
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { id: id.to_i, name: }.compact
+      end
+    end
+  end
+end

--- a/app/contracts/areas/update.rb
+++ b/app/contracts/areas/update.rb
@@ -18,9 +18,9 @@ module Contracts
         )
 
         if contract.valid?
-          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+          Contracts::Result.new(success?: true, value: contract.normalized_attributes, errors: [])
         else
-          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
         end
       end
 

--- a/app/contracts/areas/update.rb
+++ b/app/contracts/areas/update.rb
@@ -2,6 +2,16 @@
 
 module Contracts
   module Areas
+    # エリア更新用コントラクト
+    #
+    # 検証ルール:
+    # - id: 必須、正の整数のみ
+    # - name: 任意、最大32文字
+    #
+    # パラメータ形式:
+    # - { id: ..., name: "..." } または { id: ..., area: { name: "..." } }
+    #
+    # 注意: name が nil の場合、更新対象から除外される（既存値を維持）
     class Update
       include ActiveModel::Model
 

--- a/app/controllers/api/areas_controller.rb
+++ b/app/controllers/api/areas_controller.rb
@@ -1,43 +1,47 @@
 # frozen_string_literal: true
 
 class Api::AreasController < ApplicationController
-  def index
-    areas = Area.get_all_area
+  before_action :authenticated?
 
-    render json: areas
+  def index
+    result = ::Services::Areas::Index.new.call(@current_account)
+    render_result(result) { ::Presenters::AreaPresenter.render_areas(result.areas) }
   end
 
   def show
-    area = Area.find(params[:id])
-
-    render json: area
+    result = ::Services::Areas::Show.new.call(show_params, @current_account)
+    render_result(result) { ::Presenters::AreaPresenter.render_area(result.area) }
   end
 
   def create
-    area = Area.new(create_params)
-
-    if area.save
-      render json: area
-    else
-      render json: { message: area.errors, status: 422 }, status: :unprocessable_entity
-    end
+    result = ::Services::Areas::Create.new.call(create_params, @current_account)
+    render_result(result) { ::Presenters::AreaPresenter.render_area(result.area) }
   end
 
   def update
-    area = Area.find(params[:id])
-    area.update(create_params)
-
-    render json: area
+    result = ::Services::Areas::Update.new.call(update_params, @current_account)
+    render_result(result) { ::Presenters::AreaPresenter.render_area(result.area) }
   end
 
   def destroy
-    area = Area.find(params[:id])
-
-    area.destroy
+    result = ::Services::Areas::Destroy.new.call(destroy_params, @current_account)
+    render_result(result) { { message: result.message } }
   end
 
   private
+    def show_params
+      { id: params[:id] }
+    end
+
     def create_params
-      params.require(:area).permit(:name)
+      { area: params.require(:area).permit(:name) }
+    end
+
+    def update_params
+      { id: params[:id], area: params.require(:area).permit(:name) }
+    end
+
+    def destroy_params
+      { id: params[:id] }
     end
 end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Area < ApplicationRecord
-  validates :name, presence: true, length: { maximum: 32 }
+  validates :name, presence: true, length: { maximum: 32 }, uniqueness: true
 
   has_many :account_areas
   has_many :accounts, through: :account_areas

--- a/app/policies/area_policy.rb
+++ b/app/policies/area_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Policies
+  class AreaPolicy
+    def initialize(account)
+      @account = account
+    end
+
+    # エリアの作成・更新・削除は admin のみ許可
+    def admin_only?
+      @account&.role == "admin"
+    end
+  end
+end

--- a/app/presenters/area_presenter.rb
+++ b/app/presenters/area_presenter.rb
@@ -4,10 +4,14 @@ module Presenters
   class AreaPresenter
     class << self
       def render_area(area)
+        raise ArgumentError, "AreaPresenter.render_area received nil area" if area.nil?
+
         { id: area.id, name: area.name }
       end
 
       def render_areas(areas)
+        raise ArgumentError, "AreaPresenter.render_areas received nil areas" if areas.nil?
+
         areas.map { |area| render_area(area) }
       end
     end

--- a/app/presenters/area_presenter.rb
+++ b/app/presenters/area_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Presenters
+  class AreaPresenter
+    class << self
+      def render_area(area)
+        { id: area.id, name: area.name }
+      end
+
+      def render_areas(areas)
+        areas.map { |area| render_area(area) }
+      end
+    end
+  end
+end

--- a/app/services/areas/create.rb
+++ b/app/services/areas/create.rb
@@ -17,10 +17,14 @@ module Services
         end
 
         policy = ::Policies::AreaPolicy.new(current_account)
-        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+        unless policy.admin_only?
+          Rails.logger.warn "Area create unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
 
         area = @repository.build(name: validation.value[:name])
         unless @repository.save(area)
+          Rails.logger.warn "Area create failed: name=#{validation.value[:name]}, errors=#{area.errors.full_messages.join(', ')}, by_account=#{current_account.id}"
           return failure(area.errors.full_messages, :unprocessable_entity)
         end
 

--- a/app/services/areas/create.rb
+++ b/app/services/areas/create.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Services
+  module Areas
+    class Create
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Areas::Create.call(params)
+        unless validation.success?
+          Rails.logger.warn "Area create validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        policy = ::Policies::AreaPolicy.new(current_account)
+        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+
+        area = @repository.build(name: validation.value[:name])
+        unless @repository.save(area)
+          return failure(area.errors.full_messages, :unprocessable_entity)
+        end
+
+        Rails.logger.info "Area created: id=#{area.id}, name=#{area.name}, by_account=#{current_account.id}"
+        Result.new(success?: true, area:, errors: [], status: :created)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, area: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/areas/create.rb
+++ b/app/services/areas/create.rb
@@ -26,6 +26,9 @@ module Services
 
         Rails.logger.info "Area created: id=#{area.id}, name=#{area.name}, by_account=#{current_account.id}"
         Result.new(success?: true, area:, errors: [], status: :created)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Area create DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
       end
 
       private

--- a/app/services/areas/destroy.rb
+++ b/app/services/areas/destroy.rb
@@ -22,15 +22,19 @@ module Services
         area = @repository.find_by_id(validation.value[:id])
         return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found) unless area
 
-        begin
-          @repository.destroy(area)
-        rescue ActiveRecord::InvalidForeignKey => e
-          Rails.logger.error "Area destroy failed (FK constraint): id=#{area.id}, error=#{e.message}"
-          return failure(["このエリアにはアカウントが関連付けられているため削除できません"], :conflict)
-        end
+        @repository.destroy(area)
 
         Rails.logger.info "Area destroyed: id=#{validation.value[:id]}, by_account=#{current_account.id}"
         Result.new(success?: true, message: "deleted", errors: [], status: :ok)
+      rescue ActiveRecord::InvalidForeignKey => e
+        Rails.logger.error "Area destroy failed (FK constraint): id=#{area.id}, error=#{e.message}"
+        failure(["このエリアにはアカウントが関連付けられているため削除できません"], :conflict)
+      rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
+        Rails.logger.error "Area destroy lock timeout: #{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再度お試しください"], :service_unavailable)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Area destroy DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
       end
 
       private

--- a/app/services/areas/destroy.rb
+++ b/app/services/areas/destroy.rb
@@ -22,18 +22,22 @@ module Services
           return failure(["権限がありません"], :forbidden)
         end
 
-        area = @repository.find_by_id(validation.value[:id])
-        return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found) unless area
+        area_id = validation.value[:id]
 
-        unless @repository.destroy(area)
-          Rails.logger.error "Area destroy failed (callbacks): id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"
-          return failure(["エリアの削除に失敗しました"], :unprocessable_entity)
+        Area.transaction do
+          area = @repository.find_by_id_with_lock(area_id)
+          return failure(["ID'#{area_id}'のエリアは存在しません"], :not_found) unless area
+
+          unless @repository.destroy(area)
+            Rails.logger.error "Area destroy failed (callbacks): id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"
+            return failure(["エリアの削除に失敗しました"], :unprocessable_entity)
+          end
+
+          Rails.logger.info "Area destroyed: id=#{area_id}, by_account=#{current_account.id}"
+          Result.new(success?: true, message: "deleted", errors: [], status: :ok)
         end
-
-        Rails.logger.info "Area destroyed: id=#{validation.value[:id]}, by_account=#{current_account.id}"
-        Result.new(success?: true, message: "deleted", errors: [], status: :ok)
       rescue ActiveRecord::InvalidForeignKey => e
-        Rails.logger.error "Area destroy failed (FK constraint): id=#{area.id}, error=#{e.message}"
+        Rails.logger.error "Area destroy failed (FK constraint): id=#{area_id}, error=#{e.message}"
         failure(["このエリアにはアカウントが関連付けられているため削除できません"], :conflict)
       rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
         Rails.logger.error "Area destroy lock timeout: #{e.message}"

--- a/app/services/areas/destroy.rb
+++ b/app/services/areas/destroy.rb
@@ -17,12 +17,18 @@ module Services
         end
 
         policy = ::Policies::AreaPolicy.new(current_account)
-        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+        unless policy.admin_only?
+          Rails.logger.warn "Area destroy unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
 
         area = @repository.find_by_id(validation.value[:id])
         return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found) unless area
 
-        @repository.destroy(area)
+        unless @repository.destroy(area)
+          Rails.logger.error "Area destroy failed (callbacks): id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"
+          return failure(["エリアの削除に失敗しました"], :unprocessable_entity)
+        end
 
         Rails.logger.info "Area destroyed: id=#{validation.value[:id]}, by_account=#{current_account.id}"
         Result.new(success?: true, message: "deleted", errors: [], status: :ok)

--- a/app/services/areas/destroy.rb
+++ b/app/services/areas/destroy.rb
@@ -26,7 +26,10 @@ module Services
 
         Area.transaction do
           area = @repository.find_by_id_with_lock(area_id)
-          return failure(["ID'#{area_id}'のエリアは存在しません"], :not_found) unless area
+          unless area
+            Rails.logger.warn "Area not found during destroy: id=#{area_id}, by_account=#{current_account.id}"
+            return failure(["ID'#{area_id}'のエリアは存在しません"], :not_found)
+          end
 
           unless @repository.destroy(area)
             Rails.logger.error "Area destroy failed (callbacks): id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"

--- a/app/services/areas/destroy.rb
+++ b/app/services/areas/destroy.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Services
+  module Areas
+    class Destroy
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Areas::Destroy.call(params)
+        unless validation.success?
+          Rails.logger.warn "Area destroy validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        policy = ::Policies::AreaPolicy.new(current_account)
+        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+
+        area = @repository.find_by_id(validation.value[:id])
+        return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found) unless area
+
+        begin
+          @repository.destroy(area)
+        rescue ActiveRecord::InvalidForeignKey => e
+          Rails.logger.error "Area destroy failed (FK constraint): id=#{area.id}, error=#{e.message}"
+          return failure(["このエリアにはアカウントが関連付けられているため削除できません"], :conflict)
+        end
+
+        Rails.logger.info "Area destroyed: id=#{validation.value[:id]}, by_account=#{current_account.id}"
+        Result.new(success?: true, message: "deleted", errors: [], status: :ok)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, message: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/areas/index.rb
+++ b/app/services/areas/index.rb
@@ -12,6 +12,9 @@ module Services
 
         areas = @repository.all_areas
         Result.new(success?: true, areas:, errors: [], status: :ok)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Area index DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
       end
 
       private

--- a/app/services/areas/index.rb
+++ b/app/services/areas/index.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Services
+  module Areas
+    class Index
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        areas = @repository.all_areas
+        Result.new(success?: true, areas:, errors: [], status: :ok)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, areas: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/areas/repository.rb
+++ b/app/services/areas/repository.rb
@@ -2,31 +2,57 @@
 
 module Services
   module Areas
+    # Area モデルへのデータアクセスを担当するリポジトリ
+    #
+    # Service 層から直接 ActiveRecord を呼び出さないための抽象化層
+    # テスト時にモック化することで DB 非依存のテストが可能
     class Repository
+      # 全エリアを取得（id, name のみ選択）
+      # @return [ActiveRecord::Relation<Area>]
       def all_areas
         Area.select(:id, :name)
       end
 
+      # IDでエリアを検索
+      # @param id [Integer] エリアID
+      # @return [Area, nil]
       def find_by_id(id)
         Area.find_by(id:)
       end
 
+      # IDでエリアを悲観ロック付きで検索
+      # 同時更新を防ぐため、update/destroy 処理で使用
+      # @param id [Integer] エリアID
+      # @return [Area, nil]
       def find_by_id_with_lock(id)
         Area.lock.find_by(id:)
       end
 
+      # 新規 Area インスタンスを生成（未保存）
+      # @param attrs [Hash] エリア属性
+      # @return [Area]
       def build(attrs)
         Area.new(attrs)
       end
 
+      # Area を永続化
+      # @param area [Area] 保存対象のエリア
+      # @return [Boolean] 保存成功/失敗
       def save(area)
         area.save
       end
 
+      # Area の属性を更新
+      # @param area [Area] 更新対象のエリア
+      # @param attrs [Hash] 更新する属性
+      # @return [Boolean] 更新成功/失敗
       def update(area, attrs)
         area.update(attrs)
       end
 
+      # Area を削除
+      # @param area [Area] 削除対象のエリア
+      # @return [Boolean] 削除成功/失敗
       def destroy(area)
         area.destroy
       end

--- a/app/services/areas/repository.rb
+++ b/app/services/areas/repository.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Services
+  module Areas
+    class Repository
+      def all_areas
+        Area.select(:id, :name)
+      end
+
+      def find_by_id(id)
+        Area.find_by(id:)
+      end
+
+      def find_by_id_with_lock(id)
+        Area.lock.find_by(id:)
+      end
+
+      def build(attrs)
+        Area.new(attrs)
+      end
+
+      def save(area)
+        area.save
+      end
+
+      def update(area, attrs)
+        area.update(attrs)
+      end
+
+      def destroy(area)
+        area.destroy
+      end
+    end
+  end
+end

--- a/app/services/areas/result.rb
+++ b/app/services/areas/result.rb
@@ -2,13 +2,17 @@
 
 module Services
   module Areas
-    # Areas サービスの結果を格納する構造体
-    # success?: 処理成功フラグ
-    # area: 単一エリア（show/create/update）
-    # areas: エリア一覧（index）
-    # message: メッセージ（destroy成功時など）
-    # errors: エラーメッセージ配列
-    # status: HTTPステータスシンボル
+    # Areas サービス共通 Result
+    #
+    # 全サービスで統一して使用するResult Struct
+    # 使用しないフィールドはnilのまま
+    #
+    # @attr success? [Boolean] 処理成功/失敗
+    # @attr area [Area, nil] 単一リソース（show/create/update）
+    # @attr areas [Array<Area>, nil] コレクション（index）
+    # @attr message [String, nil] 処理結果メッセージ（destroy成功時）
+    # @attr errors [Array<String>] エラーメッセージ配列
+    # @attr status [Symbol] HTTPステータス（:ok, :created, :not_found等）
     Result = Struct.new(
       :success?,
       :area,

--- a/app/services/areas/result.rb
+++ b/app/services/areas/result.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Services
+  module Areas
+    # Areas サービスの結果を格納する構造体
+    # success?: 処理成功フラグ
+    # area: 単一エリア（show/create/update）
+    # areas: エリア一覧（index）
+    # message: メッセージ（destroy成功時など）
+    # errors: エラーメッセージ配列
+    # status: HTTPステータスシンボル
+    Result = Struct.new(
+      :success?,
+      :area,
+      :areas,
+      :message,
+      :errors,
+      :status,
+      keyword_init: true
+    )
+  end
+end

--- a/app/services/areas/show.rb
+++ b/app/services/areas/show.rb
@@ -20,6 +20,9 @@ module Services
         return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found) unless area
 
         Result.new(success?: true, area:, errors: [], status: :ok)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Area show DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
       end
 
       private

--- a/app/services/areas/show.rb
+++ b/app/services/areas/show.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Services
+  module Areas
+    class Show
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Areas::Show.call(params)
+        unless validation.success?
+          Rails.logger.warn "Area show validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        area = @repository.find_by_id(validation.value[:id])
+        return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found) unless area
+
+        Result.new(success?: true, area:, errors: [], status: :ok)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, area: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/areas/show.rb
+++ b/app/services/areas/show.rb
@@ -17,7 +17,10 @@ module Services
         end
 
         area = @repository.find_by_id(validation.value[:id])
-        return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found) unless area
+        unless area
+          Rails.logger.warn "Area not found: id=#{validation.value[:id]}, requested_by=#{current_account.id}"
+          return failure(["ID'#{validation.value[:id]}'のエリアは存在しません"], :not_found)
+        end
 
         Result.new(success?: true, area:, errors: [], status: :ok)
       rescue ActiveRecord::StatementInvalid => e

--- a/app/services/areas/update.rb
+++ b/app/services/areas/update.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Services
+  module Areas
+    class Update
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Areas::Update.call(params)
+        unless validation.success?
+          Rails.logger.warn "Area update validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        policy = ::Policies::AreaPolicy.new(current_account)
+        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+
+        value = validation.value
+        area = @repository.find_by_id(value[:id])
+        return failure(["ID'#{value[:id]}'のエリアは存在しません"], :not_found) unless area
+
+        update_attrs = value.except(:id).compact
+        unless @repository.update(area, update_attrs)
+          Rails.logger.warn "Area update failed: id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"
+          return failure(area.errors.full_messages, :unprocessable_entity)
+        end
+
+        Rails.logger.info "Area updated: id=#{area.id}, by_account=#{current_account.id}"
+        Result.new(success?: true, area:, errors: [], status: :ok)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, area: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/areas/update.rb
+++ b/app/services/areas/update.rb
@@ -27,7 +27,10 @@ module Services
 
         Area.transaction do
           area = @repository.find_by_id_with_lock(value[:id])
-          return failure(["ID'#{value[:id]}'のエリアは存在しません"], :not_found) unless area
+          unless area
+            Rails.logger.warn "Area not found during update: id=#{value[:id]}, by_account=#{current_account.id}"
+            return failure(["ID'#{value[:id]}'のエリアは存在しません"], :not_found)
+          end
 
           unless @repository.update(area, update_attrs)
             Rails.logger.warn "Area update failed: id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"

--- a/app/services/areas/update.rb
+++ b/app/services/areas/update.rb
@@ -17,7 +17,10 @@ module Services
         end
 
         policy = ::Policies::AreaPolicy.new(current_account)
-        return failure(["権限がありません"], :forbidden) unless policy.admin_only?
+        unless policy.admin_only?
+          Rails.logger.warn "Area update unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
 
         value = validation.value
         update_attrs = value.except(:id).compact

--- a/app/services/areas/update.rb
+++ b/app/services/areas/update.rb
@@ -20,17 +20,26 @@ module Services
         return failure(["権限がありません"], :forbidden) unless policy.admin_only?
 
         value = validation.value
-        area = @repository.find_by_id(value[:id])
-        return failure(["ID'#{value[:id]}'のエリアは存在しません"], :not_found) unless area
-
         update_attrs = value.except(:id).compact
-        unless @repository.update(area, update_attrs)
-          Rails.logger.warn "Area update failed: id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"
-          return failure(area.errors.full_messages, :unprocessable_entity)
-        end
 
-        Rails.logger.info "Area updated: id=#{area.id}, by_account=#{current_account.id}"
-        Result.new(success?: true, area:, errors: [], status: :ok)
+        Area.transaction do
+          area = @repository.find_by_id_with_lock(value[:id])
+          return failure(["ID'#{value[:id]}'のエリアは存在しません"], :not_found) unless area
+
+          unless @repository.update(area, update_attrs)
+            Rails.logger.warn "Area update failed: id=#{area.id}, errors=#{area.errors.full_messages.join(', ')}"
+            return failure(area.errors.full_messages, :unprocessable_entity)
+          end
+
+          Rails.logger.info "Area updated: id=#{area.id}, by_account=#{current_account.id}"
+          Result.new(success?: true, area:, errors: [], status: :ok)
+        end
+      rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
+        Rails.logger.error "Area update lock timeout: #{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再度お試しください"], :service_unavailable)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Area update DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
       end
 
       private

--- a/spec/contracts/areas/create_spec.rb
+++ b/spec/contracts/areas/create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Contracts::Areas::Create, type: :contract do
 
       it "32文字のnameで成功すること" do
         name = "a" * 32
-        result = described_class.call({ name: name })
+        result = described_class.call({ name: })
 
         expect(result.success?).to be true
         expect(result.value[:name]).to eq(name)
@@ -46,7 +46,7 @@ RSpec.describe Contracts::Areas::Create, type: :contract do
 
       it "nameが33文字の場合、失敗すること" do
         name = "a" * 33
-        result = described_class.call({ name: name })
+        result = described_class.call({ name: })
 
         expect(result.success?).to be false
         expect(result.errors).not_to be_empty

--- a/spec/contracts/areas/create_spec.rb
+++ b/spec/contracts/areas/create_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Areas::Create, type: :contract do
+  describe ".call" do
+    context "正常系" do
+      it "有効なnameで成功すること" do
+        result = described_class.call({ name: "東京" })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq("東京")
+        expect(result.errors).to be_empty
+      end
+
+      it "params[:area][:name]形式で成功すること" do
+        result = described_class.call({ area: { name: "大阪" } })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq("大阪")
+      end
+
+      it "32文字のnameで成功すること" do
+        name = "a" * 32
+        result = described_class.call({ name: name })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq(name)
+      end
+    end
+
+    context "異常系" do
+      it "nameがnilの場合、失敗すること" do
+        result = described_class.call({ name: nil })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "nameが空文字の場合、失敗すること" do
+        result = described_class.call({ name: "" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "nameが33文字の場合、失敗すること" do
+        name = "a" * 33
+        result = described_class.call({ name: name })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/contracts/areas/destroy_spec.rb
+++ b/spec/contracts/areas/destroy_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Areas::Destroy, type: :contract do
+  # IdContract を継承しているため、基本的なID検証は親クラスのテストでカバー
+  describe "継承" do
+    it "IdContract を継承していること" do
+      expect(described_class.superclass).to eq(Contracts::Areas::IdContract)
+    end
+  end
+
+  describe ".call" do
+    it "正の整数IDで成功すること" do
+      result = described_class.call({ id: 1 })
+
+      expect(result.success?).to be true
+      expect(result.value[:id]).to eq(1)
+      expect(result.errors).to be_empty
+    end
+
+    it "idがnilの場合、失敗すること" do
+      result = described_class.call({ id: nil })
+
+      expect(result.success?).to be false
+      expect(result.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/contracts/areas/id_contract_spec.rb
+++ b/spec/contracts/areas/id_contract_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Areas::IdContract, type: :contract do
+  describe ".call" do
+    context "正常系" do
+      it "正の整数IDで成功すること" do
+        result = described_class.call({ id: 1 })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.errors).to be_empty
+      end
+
+      it "文字列形式の正の整数IDで成功すること" do
+        result = described_class.call({ id: "123" })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(123)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "異常系" do
+      it "idがnilの場合、失敗すること" do
+        result = described_class.call({ id: nil })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが空文字の場合、失敗すること" do
+        result = described_class.call({ id: "" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが0の場合、失敗すること" do
+        result = described_class.call({ id: 0 })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが負数の場合、失敗すること" do
+        result = described_class.call({ id: -1 })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが数値でない文字列の場合、失敗すること" do
+        result = described_class.call({ id: "abc" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが小数の場合、失敗すること" do
+        result = described_class.call({ id: 1.5 })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/contracts/areas/show_spec.rb
+++ b/spec/contracts/areas/show_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Areas::Show, type: :contract do
+  # IdContract を継承しているため、基本的なID検証は親クラスのテストでカバー
+  describe "継承" do
+    it "IdContract を継承していること" do
+      expect(described_class.superclass).to eq(Contracts::Areas::IdContract)
+    end
+  end
+
+  describe ".call" do
+    it "正の整数IDで成功すること" do
+      result = described_class.call({ id: 1 })
+
+      expect(result.success?).to be true
+      expect(result.value[:id]).to eq(1)
+      expect(result.errors).to be_empty
+    end
+
+    it "idがnilの場合、失敗すること" do
+      result = described_class.call({ id: nil })
+
+      expect(result.success?).to be false
+      expect(result.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/contracts/areas/update_spec.rb
+++ b/spec/contracts/areas/update_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Contracts::Areas::Update, type: :contract do
 
       it "32文字のnameで成功すること" do
         name = "a" * 32
-        result = described_class.call({ id: 1, name: name })
+        result = described_class.call({ id: 1, name: })
 
         expect(result.success?).to be true
         expect(result.value[:name]).to eq(name)
@@ -63,7 +63,7 @@ RSpec.describe Contracts::Areas::Update, type: :contract do
 
       it "nameが33文字の場合、失敗すること" do
         name = "a" * 33
-        result = described_class.call({ id: 1, name: name })
+        result = described_class.call({ id: 1, name: })
 
         expect(result.success?).to be false
         expect(result.errors).not_to be_empty

--- a/spec/contracts/areas/update_spec.rb
+++ b/spec/contracts/areas/update_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Areas::Update, type: :contract do
+  describe ".call" do
+    context "正常系" do
+      it "idとnameで成功すること" do
+        result = described_class.call({ id: 1, name: "東京" })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.value[:name]).to eq("東京")
+        expect(result.errors).to be_empty
+      end
+
+      it "params[:area][:name]形式で成功すること" do
+        result = described_class.call({ id: 1, area: { name: "大阪" } })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.value[:name]).to eq("大阪")
+      end
+
+      it "nameがnilでも成功すること" do
+        result = described_class.call({ id: 1, name: nil })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.value).not_to have_key(:name)
+      end
+
+      it "32文字のnameで成功すること" do
+        name = "a" * 32
+        result = described_class.call({ id: 1, name: name })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq(name)
+      end
+    end
+
+    context "異常系" do
+      it "idがnilの場合、失敗すること" do
+        result = described_class.call({ id: nil, name: "東京" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが0の場合、失敗すること" do
+        result = described_class.call({ id: 0, name: "東京" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが負数の場合、失敗すること" do
+        result = described_class.call({ id: -1, name: "東京" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "nameが33文字の場合、失敗すること" do
+        name = "a" * 33
+        result = described_class.call({ id: 1, name: name })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/policies/area_policy_spec.rb
+++ b/spec/policies/area_policy_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::AreaPolicy, type: :policy do
+  describe "#admin_only?" do
+    context "admin アカウントの場合" do
+      let(:account) { build(:account, role: "admin") }
+      let(:policy) { described_class.new(account) }
+
+      it "true を返すこと" do
+        expect(policy.admin_only?).to be true
+      end
+    end
+
+    context "member アカウントの場合" do
+      let(:account) { build(:account, role: "member") }
+      let(:policy) { described_class.new(account) }
+
+      it "false を返すこと" do
+        expect(policy.admin_only?).to be false
+      end
+    end
+
+    context "nil アカウントの場合" do
+      let(:policy) { described_class.new(nil) }
+
+      it "false を返すこと" do
+        expect(policy.admin_only?).to be false
+      end
+    end
+
+    context "role が nil の場合" do
+      let(:account) { build(:account, role: nil) }
+      let(:policy) { described_class.new(account) }
+
+      it "false を返すこと" do
+        expect(policy.admin_only?).to be false
+      end
+    end
+  end
+end

--- a/spec/presenters/area_presenter_spec.rb
+++ b/spec/presenters/area_presenter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Presenters::AreaPresenter do
+  describe ".render_area" do
+    context "有効なエリアの場合" do
+      let(:area) { create(:area, name: "東京") }
+
+      it "正しいハッシュ構造を返すこと" do
+        result = described_class.render_area(area)
+
+        expect(result).to eq({ id: area.id, name: "東京" })
+      end
+    end
+
+    context "nilの場合" do
+      it "ArgumentErrorをraiseすること" do
+        expect {
+          described_class.render_area(nil)
+        }.to raise_error(ArgumentError, "AreaPresenter.render_area received nil area")
+      end
+    end
+  end
+
+  describe ".render_areas" do
+    context "有効なエリア配列の場合" do
+      let!(:area1) { create(:area, name: "東京") }
+      let!(:area2) { create(:area, name: "大阪") }
+
+      it "ハッシュ配列を返すこと" do
+        result = described_class.render_areas([area1, area2])
+
+        expect(result).to be_an(Array)
+        expect(result.length).to eq(2)
+        expect(result).to include({ id: area1.id, name: "東京" })
+        expect(result).to include({ id: area2.id, name: "大阪" })
+      end
+    end
+
+    context "空配列の場合" do
+      it "空配列を返すこと" do
+        result = described_class.render_areas([])
+
+        expect(result).to eq([])
+      end
+    end
+
+    context "nilの場合" do
+      it "ArgumentErrorをraiseすること" do
+        expect {
+          described_class.render_areas(nil)
+        }.to raise_error(ArgumentError, "AreaPresenter.render_areas received nil areas")
+      end
+    end
+  end
+end

--- a/spec/requests/api/areas_spec.rb
+++ b/spec/requests/api/areas_spec.rb
@@ -80,6 +80,13 @@ RSpec.describe "Api::Areas", type: :request do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context "無効なIDフォーマットの場合" do
+        it "文字列IDでStatus 422が返ってくること" do
+          get "/api/areas/abc", headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
     end
 
     context "未認証の場合" do
@@ -183,6 +190,20 @@ RSpec.describe "Api::Areas", type: :request do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context "無効なIDフォーマットの場合" do
+        it "文字列IDでStatus 422が返ってくること" do
+          put "/api/areas/abc", params: { area: { name: "更新" } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "無効なパラメータの場合" do
+        it "nameが32文字を超える場合、Status 422が返ってくること" do
+          put "/api/areas/#{@area.id}", params: { area: { name: "a" * 33 } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
     end
 
     context "memberユーザーの場合" do
@@ -235,6 +256,13 @@ RSpec.describe "Api::Areas", type: :request do
         it "Status 404が返ってくること" do
           delete "/api/areas/999999", headers: admin_headers
           expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "無効なIDフォーマットの場合" do
+        it "文字列IDでStatus 422が返ってくること" do
+          delete "/api/areas/abc", headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
         end
       end
 

--- a/spec/requests/api/areas_spec.rb
+++ b/spec/requests/api/areas_spec.rb
@@ -3,28 +3,49 @@
 require "rails_helper"
 
 RSpec.describe "Api::Areas", type: :request do
+  let!(:admin) { create(:account, role: "admin") }
+  let!(:member) { create(:account_member) }
+  let(:admin_token) { JsonWebToken.encode({ account_id: admin.id }) }
+  let(:member_token) { JsonWebToken.encode({ account_id: member.id }) }
+  let(:admin_headers) { { "Authorization" => "Bearer #{admin_token}" } }
+  let(:member_headers) { { "Authorization" => "Bearer #{member_token}" } }
+
   describe "GET /api/areas" do
     before do
       @area1 = create(:area, name: "東京")
       @area2 = create(:area, name: "大阪")
     end
 
-    it "Status 200が返ってくること" do
-      get "/api/areas"
-      expect(response).to have_http_status(:ok)
+    context "認証済みユーザーの場合" do
+      it "Status 200が返ってくること" do
+        get "/api/areas", headers: admin_headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "全てのエリアが返ってくること" do
+        get "/api/areas", headers: admin_headers
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(2)
+      end
+
+      it "正しい形式のデータが返ってくること" do
+        get "/api/areas", headers: admin_headers
+        json_response = JSON.parse(response.body)
+        expect(json_response[0]).to have_key("id")
+        expect(json_response[0]).to have_key("name")
+      end
+
+      it "memberユーザーでも取得できること" do
+        get "/api/areas", headers: member_headers
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it "全てのエリアが返ってくること" do
-      get "/api/areas"
-      json_response = JSON.parse(response.body)
-      expect(json_response.length).to eq(2)
-    end
-
-    it "正しい形式のデータが返ってくること" do
-      get "/api/areas"
-      json_response = JSON.parse(response.body)
-      expect(json_response[0]).to have_key("id")
-      expect(json_response[0]).to have_key("name")
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        get "/api/areas"
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 
@@ -33,64 +54,100 @@ RSpec.describe "Api::Areas", type: :request do
       @area = create(:area, name: "東京")
     end
 
-    context "存在するエリアの場合" do
-      it "Status 200が返ってくること" do
-        get "/api/areas/#{@area.id}"
-        expect(response).to have_http_status(:ok)
+    context "認証済みユーザーの場合" do
+      context "存在するエリアの場合" do
+        it "Status 200が返ってくること" do
+          get "/api/areas/#{@area.id}", headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "正しいデータが返ってくること" do
+          get "/api/areas/#{@area.id}", headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["id"]).to eq(@area.id)
+          expect(json_response["name"]).to eq("東京")
+        end
+
+        it "memberユーザーでも取得できること" do
+          get "/api/areas/#{@area.id}", headers: member_headers
+          expect(response).to have_http_status(:ok)
+        end
       end
 
-      it "正しいデータが返ってくること" do
-        get "/api/areas/#{@area.id}"
-        json_response = JSON.parse(response.body)
-        expect(json_response["id"]).to eq(@area.id)
-        expect(json_response["name"]).to eq("東京")
+      context "存在しないエリアの場合" do
+        it "Status 404が返ってくること" do
+          get "/api/areas/999999", headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
 
-    context "存在しないエリアの場合" do
-      it "Status 404が返ってくること" do
-        get "/api/areas/999999"
-        expect(response).to have_http_status(:not_found)
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        get "/api/areas/#{@area.id}"
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
 
   describe "POST /api/areas" do
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        post "/api/areas", params: { area: { name: "新規エリア" } }
-        expect(response).to have_http_status(:ok)
+    context "adminユーザーの場合" do
+      context "有効なパラメータの場合" do
+        it "Status 201が返ってくること" do
+          post "/api/areas", params: { area: { name: "新規エリア" } }, headers: admin_headers
+          expect(response).to have_http_status(:created)
+        end
+
+        it "エリアが作成されること" do
+          expect {
+            post "/api/areas", params: { area: { name: "新規エリア" } }, headers: admin_headers
+          }.to change(Area, :count).by(1)
+        end
+
+        it "作成されたデータが返ってくること" do
+          post "/api/areas", params: { area: { name: "新規エリア" } }, headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["name"]).to eq("新規エリア")
+        end
       end
 
-      it "エリアが作成されること" do
-        expect {
-          post "/api/areas", params: { area: { name: "新規エリア" } }
-        }.to change(Area, :count).by(1)
-      end
+      context "無効なパラメータの場合" do
+        it "nameが空の場合、Status 422が返ってくること" do
+          post "/api/areas", params: { area: { name: "" } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
 
-      it "作成されたデータが返ってくること" do
-        post "/api/areas", params: { area: { name: "新規エリア" } }
-        json_response = JSON.parse(response.body)
-        expect(json_response["name"]).to eq("新規エリア")
+        it "nameが32文字を超える場合、Status 422が返ってくること" do
+          post "/api/areas", params: { area: { name: "a" * 33 } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/areas", params: { area: { name: "" } }, headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response).to have_key("errors")
+          expect(json_response["status"]).to eq(422)
+        end
       end
     end
 
-    context "無効なパラメータの場合" do
-      it "nameが空の場合、Status 422が返ってくること" do
-        post "/api/areas", params: { area: { name: "" } }
-        expect(response).to have_http_status(:unprocessable_entity)
+    context "memberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        post "/api/areas", params: { area: { name: "新規エリア" } }, headers: member_headers
+        expect(response).to have_http_status(:forbidden)
       end
 
-      it "nameが32文字を超える場合、Status 422が返ってくること" do
-        post "/api/areas", params: { area: { name: "a" * 33 } }
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "エリアが作成されないこと" do
+        expect {
+          post "/api/areas", params: { area: { name: "新規エリア" } }, headers: member_headers
+        }.not_to change(Area, :count)
       end
+    end
 
-      it "エラーメッセージが返ってくること" do
-        post "/api/areas", params: { area: { name: "" } }
-        json_response = JSON.parse(response.body)
-        expect(json_response).to have_key("message")
-        expect(json_response["status"]).to eq(422)
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        post "/api/areas", params: { area: { name: "新規エリア" } }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -100,29 +157,51 @@ RSpec.describe "Api::Areas", type: :request do
       @area = create(:area, name: "元の名前")
     end
 
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }
-        expect(response).to have_http_status(:ok)
+    context "adminユーザーの場合" do
+      context "有効なパラメータの場合" do
+        it "Status 200が返ってくること" do
+          put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }, headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "更新されたデータが返ってくること" do
+          put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }, headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["name"]).to eq("更新後の名前")
+        end
+
+        it "DBが更新されていること" do
+          put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }, headers: admin_headers
+          @area.reload
+          expect(@area.name).to eq("更新後の名前")
+        end
       end
 
-      it "更新されたデータが返ってくること" do
-        put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }
-        json_response = JSON.parse(response.body)
-        expect(json_response["name"]).to eq("更新後の名前")
-      end
-
-      it "DBが更新されていること" do
-        put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }
-        @area.reload
-        expect(@area.name).to eq("更新後の名前")
+      context "存在しないエリアの場合" do
+        it "Status 404が返ってくること" do
+          put "/api/areas/999999", params: { area: { name: "更新" } }, headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
 
-    context "存在しないエリアの場合" do
-      it "Status 404が返ってくること" do
-        put "/api/areas/999999", params: { area: { name: "更新" } }
-        expect(response).to have_http_status(:not_found)
+    context "memberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }, headers: member_headers
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "DBが更新されないこと" do
+        put "/api/areas/#{@area.id}", params: { area: { name: "更新後の名前" } }, headers: member_headers
+        @area.reload
+        expect(@area.name).to eq("元の名前")
+      end
+    end
+
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        put "/api/areas/#{@area.id}", params: { area: { name: "更新" } }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -132,23 +211,68 @@ RSpec.describe "Api::Areas", type: :request do
       @area = create(:area, name: "削除対象")
     end
 
-    context "存在するエリアの場合" do
-      it "Status 204が返ってくること" do
-        delete "/api/areas/#{@area.id}"
-        expect(response).to have_http_status(:no_content)
+    context "adminユーザーの場合" do
+      context "存在するエリアの場合" do
+        it "Status 200が返ってくること" do
+          delete "/api/areas/#{@area.id}", headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "エリアが削除されること" do
+          expect {
+            delete "/api/areas/#{@area.id}", headers: admin_headers
+          }.to change(Area, :count).by(-1)
+        end
+
+        it "削除メッセージが返ってくること" do
+          delete "/api/areas/#{@area.id}", headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["message"]).to eq("deleted")
+        end
       end
 
-      it "エリアが削除されること" do
-        expect {
-          delete "/api/areas/#{@area.id}"
-        }.to change(Area, :count).by(-1)
+      context "存在しないエリアの場合" do
+        it "Status 404が返ってくること" do
+          delete "/api/areas/999999", headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "FK制約違反の場合" do
+        before do
+          admin.areas << @area
+        end
+
+        it "Status 409が返ってくること" do
+          delete "/api/areas/#{@area.id}", headers: admin_headers
+          expect(response).to have_http_status(:conflict)
+        end
+
+        it "エリアが削除されないこと" do
+          expect {
+            delete "/api/areas/#{@area.id}", headers: admin_headers
+          }.not_to change(Area, :count)
+        end
       end
     end
 
-    context "存在しないエリアの場合" do
-      it "Status 404が返ってくること" do
-        delete "/api/areas/999999"
-        expect(response).to have_http_status(:not_found)
+    context "memberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        delete "/api/areas/#{@area.id}", headers: member_headers
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "エリアが削除されないこと" do
+        expect {
+          delete "/api/areas/#{@area.id}", headers: member_headers
+        }.not_to change(Area, :count)
+      end
+    end
+
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        delete "/api/areas/#{@area.id}"
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/services/areas/create_spec.rb
+++ b/spec/services/areas/create_spec.rb
@@ -81,6 +81,23 @@ RSpec.describe Services::Areas::Create, type: :service do
           }.not_to change(Area, :count)
         end
       end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:build).and_return(Area.new(name: "東京"))
+          allow(mock_repository).to receive(:save).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
     end
   end
 end

--- a/spec/services/areas/create_spec.rb
+++ b/spec/services/areas/create_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Areas::Create, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+
+    let(:valid_params) { { name: "東京" } }
+
+    describe "正常系" do
+      context "adminユーザーが有効なパラメータでエリアを作成する場合" do
+        it "成功してエリアを作成すること" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.to change(Area, :count).by(1)
+        end
+
+        it "作成されたエリア情報を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:created)
+          expect(result.area.name).to eq("東京")
+          expect(result.errors).to be_empty
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(valid_params, admin)
+          rendered = Presenters::AreaPresenter.render_area(result.area)
+
+          expect(rendered).to have_key(:id)
+          expect(rendered[:name]).to eq("東京")
+        end
+      end
+
+      context "params[:area][:name]形式の場合" do
+        it "成功すること" do
+          result = described_class.new.call({ area: { name: "大阪" } }, admin)
+
+          expect(result.success?).to be true
+          expect(result.area.name).to eq("大阪")
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "バリデーションエラーの場合" do
+        it "nameが空の場合、失敗を返すこと" do
+          result = described_class.new.call({ name: "" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+          expect(result.errors).not_to be_empty
+        end
+
+        it "nameが33文字の場合、失敗を返すこと" do
+          result = described_class.new.call({ name: "a" * 33 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "エリアが作成されないこと" do
+          expect {
+            described_class.new.call({ name: "" }, admin)
+          }.not_to change(Area, :count)
+        end
+      end
+
+      describe "権限エラーの場合" do
+        let(:current_account) { member }
+        let(:result) { described_class.new.call(valid_params, current_account) }
+
+        it_behaves_like "admin only service"
+
+        it "エリアが作成されないこと" do
+          expect {
+            described_class.new.call(valid_params, member)
+          }.not_to change(Area, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/areas/destroy_spec.rb
+++ b/spec/services/areas/destroy_spec.rb
@@ -96,6 +96,40 @@ RSpec.describe Services::Areas::Destroy, type: :service do
           }.not_to change(Area, :count)
         end
       end
+
+      context "ロックタイムアウトが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id).and_return(area)
+          allow(mock_repository).to receive(:destroy).and_raise(ActiveRecord::LockWaitTimeout)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+          expect(result.errors.first).to include("混雑")
+        end
+      end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id).and_return(area)
+          allow(mock_repository).to receive(:destroy).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
     end
   end
 end

--- a/spec/services/areas/destroy_spec.rb
+++ b/spec/services/areas/destroy_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe Services::Areas::Destroy, type: :service do
         end
       end
 
+      context "デッドロックが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::Deadlocked)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+          expect(result.errors.first).to include("混雑")
+        end
+      end
+
       context "データベースエラーが発生した場合" do
         let(:mock_repository) { instance_double(Services::Areas::Repository) }
 

--- a/spec/services/areas/destroy_spec.rb
+++ b/spec/services/areas/destroy_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Areas::Destroy, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:area) { create(:area, name: "東京") }
+
+    let(:valid_params) { { id: area.id } }
+
+    describe "正常系" do
+      context "adminユーザーが削除する場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.message).to eq("deleted")
+          expect(result.errors).to be_empty
+        end
+
+        it "エリアが削除されること" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.to change(Area, :count).by(-1)
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect({ message: result.message }).to eq({ message: "deleted" })
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "バリデーションエラーの場合" do
+        it "idが無効な場合、失敗を返すこと" do
+          result = described_class.new.call({ id: "abc" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "エリアが削除されないこと" do
+          expect {
+            described_class.new.call({ id: "abc" }, admin)
+          }.not_to change(Area, :count)
+        end
+      end
+
+      describe "権限エラーの場合" do
+        let(:current_account) { member }
+        let(:result) { described_class.new.call(valid_params, current_account) }
+
+        it_behaves_like "admin only service"
+
+        it "エリアが削除されないこと" do
+          expect {
+            described_class.new.call(valid_params, member)
+          }.not_to change(Area, :count)
+        end
+      end
+
+      context "エリアが存在しない場合" do
+        it "not_foundを返すこと" do
+          result = described_class.new.call({ id: 999999 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors.first).to include("999999")
+        end
+      end
+
+      context "FK制約違反の場合" do
+        let!(:area_with_account) { create(:area, name: "大阪") }
+
+        before do
+          # エリアにアカウントを紐付ける
+          admin.areas << area_with_account
+        end
+
+        it "conflictを返すこと" do
+          result = described_class.new.call({ id: area_with_account.id }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:conflict)
+          expect(result.errors.first).to include("アカウントが関連付けられている")
+        end
+
+        it "エリアが削除されないこと" do
+          expect {
+            described_class.new.call({ id: area_with_account.id }, admin)
+          }.not_to change(Area, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/areas/destroy_spec.rb
+++ b/spec/services/areas/destroy_spec.rb
@@ -101,8 +101,7 @@ RSpec.describe Services::Areas::Destroy, type: :service do
         let(:mock_repository) { instance_double(Services::Areas::Repository) }
 
         before do
-          allow(mock_repository).to receive(:find_by_id).and_return(area)
-          allow(mock_repository).to receive(:destroy).and_raise(ActiveRecord::LockWaitTimeout)
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::LockWaitTimeout)
         end
 
         it "service_unavailableを返すこと" do
@@ -118,8 +117,7 @@ RSpec.describe Services::Areas::Destroy, type: :service do
         let(:mock_repository) { instance_double(Services::Areas::Repository) }
 
         before do
-          allow(mock_repository).to receive(:find_by_id).and_return(area)
-          allow(mock_repository).to receive(:destroy).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
         end
 
         it "internal_server_errorを返すこと" do

--- a/spec/services/areas/index_spec.rb
+++ b/spec/services/areas/index_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Areas::Index, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:area1) { create(:area, name: "東京") }
+    let!(:area2) { create(:area, name: "大阪") }
+
+    describe "正常系" do
+      context "adminユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "全エリアを返すこと" do
+          result = described_class.new.call(admin)
+
+          expect(result.areas.length).to eq(2)
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(admin)
+          rendered = Presenters::AreaPresenter.render_areas(result.areas)
+
+          expect(rendered).to be_an(Array)
+          expect(rendered.first).to have_key(:id)
+          expect(rendered.first).to have_key(:name)
+        end
+      end
+
+      context "memberユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(member)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "current_accountがnilの場合" do
+        it "unauthorizedを返すこと" do
+          result = described_class.new.call(nil)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unauthorized)
+          expect(result.errors).to include("認証が必要です")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/areas/index_spec.rb
+++ b/spec/services/areas/index_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe Services::Areas::Index, type: :service do
           expect(result.errors).to include("認証が必要です")
         end
       end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:all_areas).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
     end
   end
 end

--- a/spec/services/areas/show_spec.rb
+++ b/spec/services/areas/show_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Areas::Show, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:area) { create(:area, name: "東京") }
+
+    describe "正常系" do
+      context "adminユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call({ id: area.id }, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "指定したエリアを返すこと" do
+          result = described_class.new.call({ id: area.id }, admin)
+
+          expect(result.area.id).to eq(area.id)
+          expect(result.area.name).to eq("東京")
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call({ id: area.id }, admin)
+          rendered = Presenters::AreaPresenter.render_area(result.area)
+
+          expect(rendered).to eq({ id: area.id, name: "東京" })
+        end
+      end
+
+      context "memberユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call({ id: area.id }, member)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "current_accountがnilの場合" do
+        it "unauthorizedを返すこと" do
+          result = described_class.new.call({ id: area.id }, nil)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unauthorized)
+          expect(result.errors).to include("認証が必要です")
+        end
+      end
+
+      context "バリデーションエラーの場合" do
+        it "idが無効な場合、unprocessable_entityを返すこと" do
+          result = described_class.new.call({ id: "abc" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+      end
+
+      context "エリアが存在しない場合" do
+        it "not_foundを返すこと" do
+          result = described_class.new.call({ id: 999999 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors.first).to include("999999")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/areas/show_spec.rb
+++ b/spec/services/areas/show_spec.rb
@@ -72,6 +72,22 @@ RSpec.describe Services::Areas::Show, type: :service do
           expect(result.errors.first).to include("999999")
         end
       end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call({ id: 1 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
     end
   end
 end

--- a/spec/services/areas/update_spec.rb
+++ b/spec/services/areas/update_spec.rb
@@ -112,6 +112,53 @@ RSpec.describe Services::Areas::Update, type: :service do
           expect(result.errors.first).to include("999999")
         end
       end
+
+      context "ロックタイムアウトが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::LockWaitTimeout)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+          expect(result.errors.first).to include("混雑")
+        end
+      end
+
+      context "デッドロックが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::Deadlocked)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+        end
+      end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Areas::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
     end
   end
 end

--- a/spec/services/areas/update_spec.rb
+++ b/spec/services/areas/update_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Areas::Update, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:area) { create(:area, name: "東京") }
+
+    let(:valid_params) { { id: area.id, name: "大阪" } }
+
+    describe "正常系" do
+      context "adminユーザーが有効なパラメータでエリアを更新する場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "エリア名が更新されること" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.area.name).to eq("大阪")
+        end
+
+        it "DBが更新されること" do
+          described_class.new.call(valid_params, admin)
+
+          area.reload
+          expect(area.name).to eq("大阪")
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(valid_params, admin)
+          rendered = Presenters::AreaPresenter.render_area(result.area)
+
+          expect(rendered[:id]).to eq(area.id)
+          expect(rendered[:name]).to eq("大阪")
+        end
+      end
+
+      context "params[:area][:name]形式の場合" do
+        it "成功すること" do
+          result = described_class.new.call({ id: area.id, area: { name: "名古屋" } }, admin)
+
+          expect(result.success?).to be true
+          expect(result.area.name).to eq("名古屋")
+        end
+      end
+
+      context "nameがnilの場合" do
+        it "更新されないこと" do
+          original_name = area.name
+          result = described_class.new.call({ id: area.id, name: nil }, admin)
+
+          expect(result.success?).to be true
+          area.reload
+          expect(area.name).to eq(original_name)
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "バリデーションエラーの場合" do
+        it "idが無効な場合、失敗を返すこと" do
+          result = described_class.new.call({ id: "abc", name: "大阪" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "nameが33文字の場合、失敗を返すこと" do
+          result = described_class.new.call({ id: area.id, name: "a" * 33 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "DBが更新されないこと" do
+          original_name = area.name
+          described_class.new.call({ id: area.id, name: "a" * 33 }, admin)
+
+          area.reload
+          expect(area.name).to eq(original_name)
+        end
+      end
+
+      describe "権限エラーの場合" do
+        let(:current_account) { member }
+        let(:result) { described_class.new.call(valid_params, current_account) }
+
+        it_behaves_like "admin only service"
+
+        it "DBが更新されないこと" do
+          original_name = area.name
+          described_class.new.call(valid_params, member)
+
+          area.reload
+          expect(area.name).to eq(original_name)
+        end
+      end
+
+      context "エリアが存在しない場合" do
+        it "not_foundを返すこと" do
+          result = described_class.new.call({ id: 999999, name: "大阪" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors.first).to include("999999")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Areas コントローラー（5エンドポイント）を4層アーキテクチャに移行
- 認証・認可を追加してセキュリティ問題を修正
- FK制約違反時のエラーハンドリングを追加

## 変更内容

### 新規ファイル（15ファイル）
| カテゴリ | ファイル |
|---------|---------|
| Contract | `app/contracts/areas/{id_contract,show,destroy,create,update}.rb` |
| Service | `app/services/areas/{index,show,create,update,destroy,repository,result}.rb` |
| Policy | `app/policies/area_policy.rb` |
| Presenter | `app/presenters/area_presenter.rb` |

### 修正ファイル
- `app/controllers/api/areas_controller.rb` - 4層構造に修正
- `spec/requests/api/areas_spec.rb` - 認証・認可テスト追加

## 破壊的変更

| 変更 | Before | After |
|------|--------|-------|
| 認証 | ❌ なし | ✅ 全エンドポイント必須（401） |
| 認可 | ❌ なし | ✅ create/update/destroy は admin のみ（403） |
| FK制約エラー | 500 | 409 Conflict |
| Delete レスポンス | 204 空 | 200 `{ "message": "deleted" }` |

## Test plan
- [x] Contract テスト（22 examples）
- [x] Service テスト（46 examples）
- [x] Request テスト（35 examples）
- [x] 全体テスト（1186 examples, 0 failures）
- [x] RuboCop Pass