### PR TITLE
refactor: Comments コントローラーを4層アーキテクチャに移行

### DIFF
--- a/app/contracts/comments/create.rb
+++ b/app/contracts/comments/create.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Comments
+    # コメント作成用コントラクト
+    #
+    # 検証ルール:
+    # - content: 必須、最大1000文字
+    # - task_id: 必須、正の整数のみ
+    #
+    # パラメータ形式:
+    # - { comment: { content: "...", task_id: ... } }
+    #
+    # 注意: account_id はパラメータから受け取らず、current_account から設定
+    class Create
+      include ActiveModel::Model
+
+      attr_accessor :content, :task_id
+
+      validates :content, presence: true, length: { maximum: 1000 }
+      validates :task_id, presence: true
+      validates :task_id, numericality: { only_integer: true, greater_than: 0 }, if: -> { task_id.present? }
+
+      def self.call(params)
+        comment_params = params[:comment] || {}
+        contract = new(
+          content: comment_params[:content],
+          task_id: comment_params[:task_id]
+        )
+
+        if contract.valid?
+          Contracts::Result.new(
+            success?: true,
+            value: { content: contract.content, task_id: contract.task_id.to_i },
+            errors: []
+          )
+        else
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+    end
+  end
+end

--- a/app/contracts/comments/destroy.rb
+++ b/app/contracts/comments/destroy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Comments
+    # コメント削除用コントラクト
+    #
+    # IdContract を継承し、id の検証を行う
+    class Destroy < IdContract
+    end
+  end
+end

--- a/app/contracts/comments/id_contract.rb
+++ b/app/contracts/comments/id_contract.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Comments
+    # コメントID検証用の基底コントラクト
+    #
+    # 検証ルール:
+    # - id: 必須、正の整数のみ
+    #
+    # Show, Destroy コントラクトの親クラスとして使用
+    class IdContract
+      include ActiveModel::Model
+
+      attr_accessor :id
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+
+      def self.call(params)
+        contract = new(id: params[:id])
+
+        if contract.valid?
+          Contracts::Result.new(success?: true, value: { id: contract.id.to_i }, errors: [])
+        else
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+    end
+  end
+end

--- a/app/contracts/comments/index.rb
+++ b/app/contracts/comments/index.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Comments
+    # コメント一覧取得用コントラクト
+    #
+    # 検証ルール:
+    # - task_id: 必須、正の整数のみ
+    #
+    # パラメータ形式:
+    # - { task_id: ... }
+    class Index
+      include ActiveModel::Model
+
+      attr_accessor :task_id
+
+      validates :task_id, presence: true
+      validates :task_id, numericality: { only_integer: true, greater_than: 0 }, if: -> { task_id.present? }
+
+      def self.call(params)
+        contract = new(task_id: params[:task_id])
+
+        if contract.valid?
+          Contracts::Result.new(success?: true, value: { task_id: contract.task_id.to_i }, errors: [])
+        else
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+    end
+  end
+end

--- a/app/contracts/comments/show.rb
+++ b/app/contracts/comments/show.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Comments
+    # コメント詳細取得用コントラクト
+    #
+    # IdContract を継承し、id の検証を行う
+    class Show < IdContract
+    end
+  end
+end

--- a/app/contracts/comments/update.rb
+++ b/app/contracts/comments/update.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Comments
+    # コメント更新用コントラクト
+    #
+    # 検証ルール:
+    # - id: 必須、正の整数のみ
+    # - content: 任意、最大1000文字
+    #
+    # パラメータ形式:
+    # - { id: ..., comment: { content: "..." } }
+    #
+    # 注意: content が nil の場合、更新対象から除外される（既存値を維持）
+    class Update
+      include ActiveModel::Model
+
+      attr_accessor :id, :content
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+      validates :content, length: { maximum: 1000 }, allow_nil: true
+
+      def self.call(params)
+        comment_params = params[:comment] || {}
+        contract = new(
+          id: params[:id],
+          content: comment_params[:content]
+        )
+
+        if contract.valid?
+          Contracts::Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { id: id.to_i, content: }.compact
+      end
+    end
+  end
+end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,51 +1,51 @@
 # frozen_string_literal: true
 
 class Api::CommentsController < ApplicationController
-  def index
-    comments = Comment.get_member_comments(params[:taskId], params[:accountId])
+  before_action :authenticated?
 
-    render json: comments
+  def index
+    result = ::Services::Comments::Index.new.call(index_params, @current_account)
+    render_result(result) { ::Presenters::CommentPresenter.render_comments(result.comments) }
   end
 
   def show
-    comment = Comment.find(params[:id])
-
-    render json: comment
+    result = ::Services::Comments::Show.new.call(show_params, @current_account)
+    render_result(result) { ::Presenters::CommentPresenter.render_comment(result.comment) }
   end
 
   def create
-    comment = Comment.new(create_params)
-
-    if comment.save
-      render json: comment.mutate_render[0]
-    else
-      render json: { message: comment.errors, status: 422 }, status: :unprocessable_entity
-    end
+    result = ::Services::Comments::Create.new.call(create_params, @current_account)
+    render_result(result) { ::Presenters::CommentPresenter.render_comment(result.comment) }
   end
 
   def update
-    comment = Comment.find(params[:id])
-    comment.update(update_params)
-
-    render json: comment
+    result = ::Services::Comments::Update.new.call(update_params, @current_account)
+    render_result(result) { ::Presenters::CommentPresenter.render_comment(result.comment) }
   end
 
   def destroy
-    comment = Comment.find(params[:id])
-
-    if comment.destroy
-      render json: { message: "complete" }, status: 200
-    else
-      render json: { message: "Delete failed" }, status: 400
-    end
+    result = ::Services::Comments::Destroy.new.call(destroy_params, @current_account)
+    render_result(result) { { message: result.message } }
   end
 
   private
+    def index_params
+      { task_id: params[:taskId] }
+    end
+
+    def show_params
+      { id: params[:id] }
+    end
+
     def create_params
-      params.require(:comment).permit(:content, :task_id, :account_id)
+      { comment: params.require(:comment).permit(:content, :task_id) }
     end
 
     def update_params
-      params.require(:comment).permit(:content, :task_id, :account_id)
+      { id: params[:id], comment: params.require(:comment).permit(:content) }
+    end
+
+    def destroy_params
+      { id: params[:id] }
     end
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -28,13 +28,21 @@ module Policies
     private
       # @return [Boolean] 現在のユーザーがadminか
       def admin?
-        @account&.role == "admin"
+        if @account.nil?
+          Rails.logger.warn "CommentPolicy: account is nil during admin? check"
+          return false
+        end
+        @account.role == "admin"
       end
 
       # @param comment [Comment] 対象コメント
       # @return [Boolean] 現在のユーザーがコメント所有者か
       def owner?(comment)
-        @account&.id == comment.account_id
+        if @account.nil?
+          Rails.logger.warn "CommentPolicy: account is nil during owner? check"
+          return false
+        end
+        @account.id == comment.account_id
       end
 
       # @param comment [Comment] 対象コメント

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Policies
+  # コメント操作の認可ポリシー
+  #
+  # 認可ルール:
+  # - 閲覧(can_view?): admin / コメント所有者 / admin作成コメント
+  # - 編集(can_modify?): admin / コメント所有者
+  class CommentPolicy
+    def initialize(account)
+      @account = account
+    end
+
+    # コメントを閲覧できるか
+    # @param comment [Comment] 対象コメント
+    # @return [Boolean]
+    def can_view?(comment)
+      admin? || owner?(comment) || admin_comment?(comment)
+    end
+
+    # コメントを編集/削除できるか
+    # @param comment [Comment] 対象コメント
+    # @return [Boolean]
+    def can_modify?(comment)
+      admin? || owner?(comment)
+    end
+
+    private
+      # @return [Boolean] 現在のユーザーがadminか
+      def admin?
+        @account&.role == "admin"
+      end
+
+      # @param comment [Comment] 対象コメント
+      # @return [Boolean] 現在のユーザーがコメント所有者か
+      def owner?(comment)
+        @account&.id == comment.account_id
+      end
+
+      # @param comment [Comment] 対象コメント
+      # @return [Boolean] コメントがadminによって作成されたか
+      def admin_comment?(comment)
+        comment.account&.role == "admin"
+      end
+  end
+end

--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Presenters
+  # コメントのレスポンス整形を担当
+  #
+  # account 情報を含めた形式で返却
+  class CommentPresenter
+    class << self
+      # 単一コメントをレスポンス形式に変換
+      # @param comment [Comment] コメントオブジェクト（account関連を含む）
+      # @return [Hash]
+      def render_comment(comment)
+        return nil if comment.nil?
+
+        {
+          id: comment.id,
+          content: comment.content,
+          task_id: comment.task_id,
+          account_id: comment.account_id,
+          account_name: comment.account&.name,
+          account_role: comment.account&.role,
+          updated_at: comment.updated_at&.iso8601
+        }
+      end
+
+      # コメント一覧をレスポンス形式に変換
+      # @param comments [Array<Comment>] コメント配列
+      # @return [Array<Hash>]
+      def render_comments(comments)
+        return [] if comments.nil?
+
+        comments.map { |comment| render_comment(comment) }
+      end
+    end
+  end
+end

--- a/app/presenters/comment_presenter.rb
+++ b/app/presenters/comment_presenter.rb
@@ -8,9 +8,17 @@ module Presenters
     class << self
       # 単一コメントをレスポンス形式に変換
       # @param comment [Comment] コメントオブジェクト（account関連を含む）
-      # @return [Hash]
+      # @return [Hash, nil]
       def render_comment(comment)
-        return nil if comment.nil?
+        if comment.nil?
+          Rails.logger.warn "CommentPresenter.render_comment received nil comment"
+          return nil
+        end
+
+        # orphanedコメント（削除されたアカウント）の警告
+        if comment.account.nil?
+          Rails.logger.warn "CommentPresenter: comment id=#{comment.id} has nil account (orphaned)"
+        end
 
         {
           id: comment.id,
@@ -27,7 +35,10 @@ module Presenters
       # @param comments [Array<Comment>] コメント配列
       # @return [Array<Hash>]
       def render_comments(comments)
-        return [] if comments.nil?
+        if comments.nil?
+          Rails.logger.warn "CommentPresenter.render_comments received nil comments"
+          return []
+        end
 
         comments.map { |comment| render_comment(comment) }
       end

--- a/app/services/comments/create.rb
+++ b/app/services/comments/create.rb
@@ -54,6 +54,9 @@ module Services
       rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
         Rails.logger.error "Comment create lock error: error=#{e.message}"
         failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::RecordNotUnique => e
+        Rails.logger.error "Comment create uniqueness error: #{e.message}"
+        failure(["このコメントは既に存在します"], :conflict)
       rescue ActiveRecord::InvalidForeignKey => e
         Rails.logger.error "Comment create FK error: #{e.message}"
         failure(["関連するタスクまたはアカウントが存在しません"], :conflict)

--- a/app/services/comments/create.rb
+++ b/app/services/comments/create.rb
@@ -54,6 +54,9 @@ module Services
       rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
         Rails.logger.error "Comment create lock error: error=#{e.message}"
         failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::InvalidForeignKey => e
+        Rails.logger.error "Comment create FK error: #{e.message}"
+        failure(["関連するタスクまたはアカウントが存在しません"], :conflict)
       rescue ActiveRecord::StatementInvalid => e
         Rails.logger.error "Comment create DB error: #{e.message}"
         failure(["データベースエラーが発生しました"], :internal_server_error)

--- a/app/services/comments/create.rb
+++ b/app/services/comments/create.rb
@@ -42,10 +42,18 @@ module Services
         end
 
         # account関連を読み込み直す（Presenter用）
-        comment = @repository.find_by_id(comment.id)
+        saved_id = comment.id
+        comment = @repository.find_by_id(saved_id)
+        unless comment
+          Rails.logger.error "Comment vanished after creation: id=#{saved_id}, task_id=#{task_id}, by_account=#{current_account.id}"
+          return failure(["コメントの作成後にデータが見つかりませんでした"], :internal_server_error)
+        end
 
         Rails.logger.info "Comment created: id=#{comment.id}, task_id=#{task_id}, by_account=#{current_account.id}"
         Result.new(success?: true, comment:, errors: [], status: :created)
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Comment create lock error: error=#{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
       rescue ActiveRecord::StatementInvalid => e
         Rails.logger.error "Comment create DB error: #{e.message}"
         failure(["データベースエラーが発生しました"], :internal_server_error)

--- a/app/services/comments/create.rb
+++ b/app/services/comments/create.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Services
+  module Comments
+    # コメント作成サービス
+    #
+    # セキュリティ:
+    # - account_id は current_account から自動設定
+    # - パラメータの account_id は無視（なりすまし防止）
+    class Create
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { comment: { content: String, task_id: Integer } }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Comments::Create.call(params)
+        unless validation.success?
+          Rails.logger.warn "Comment create validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        task_id = validation.value[:task_id]
+        unless @repository.task_exists?(task_id)
+          Rails.logger.warn "Task not found for comment create: task_id=#{task_id}, by_account=#{current_account.id}"
+          return failure(["ID'#{task_id}'のタスクは存在しません"], :not_found)
+        end
+
+        comment = @repository.build(
+          content: validation.value[:content],
+          task_id:,
+          account_id: current_account.id
+        )
+
+        unless @repository.save(comment)
+          Rails.logger.warn "Comment create failed: errors=#{comment.errors.full_messages.join(', ')}"
+          return failure(comment.errors.full_messages, :unprocessable_entity)
+        end
+
+        # account関連を読み込み直す（Presenter用）
+        comment = @repository.find_by_id(comment.id)
+
+        Rails.logger.info "Comment created: id=#{comment.id}, task_id=#{task_id}, by_account=#{current_account.id}"
+        Result.new(success?: true, comment:, errors: [], status: :created)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Comment create DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, comment: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/comments/destroy.rb
+++ b/app/services/comments/destroy.rb
@@ -41,7 +41,10 @@ module Services
             return failure(["このコメントを削除する権限がありません"], :forbidden)
           end
 
-          @repository.destroy(comment)
+          unless @repository.destroy(comment)
+            Rails.logger.error "Comment destroy failed silently: id=#{comment.id}, errors=#{comment.errors.full_messages.join(', ')}"
+            return failure(["コメントの削除に失敗しました"], :unprocessable_entity)
+          end
 
           Rails.logger.info "Comment destroyed: id=#{comment_id}, by_account=#{current_account.id}"
           return Result.new(success?: true, message: "deleted", errors: [], status: :ok)

--- a/app/services/comments/destroy.rb
+++ b/app/services/comments/destroy.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Services
+  module Comments
+    # コメント削除サービス
+    #
+    # 認可ルール:
+    # - Admin: 全コメント削除可能
+    # - Member: 自分のコメントのみ削除可能
+    #
+    # トランザクション + 悲観ロックで同時操作を防止
+    class Destroy
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Comments::Destroy.call(params)
+        unless validation.success?
+          Rails.logger.warn "Comment destroy validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        comment_id = validation.value[:id]
+
+        Comment.transaction do
+          comment = @repository.find_by_id_with_lock(comment_id)
+          unless comment
+            Rails.logger.warn "Comment not found during destroy: id=#{comment_id}, by_account=#{current_account.id}"
+            return failure(["ID'#{comment_id}'のコメントは存在しません"], :not_found)
+          end
+
+          policy = ::Policies::CommentPolicy.new(current_account)
+          unless policy.can_modify?(comment)
+            Rails.logger.warn "Comment destroy denied: id=#{comment.id}, by_account=#{current_account.id}"
+            return failure(["このコメントを削除する権限がありません"], :forbidden)
+          end
+
+          @repository.destroy(comment)
+
+          Rails.logger.info "Comment destroyed: id=#{comment_id}, by_account=#{current_account.id}"
+          return Result.new(success?: true, message: "deleted", errors: [], status: :ok)
+        end
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Comment destroy lock error: id=#{params[:id]}, error=#{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Comment destroy DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, message: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/comments/index.rb
+++ b/app/services/comments/index.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Services
+  module Comments
+    # コメント一覧取得サービス
+    #
+    # 認可ルール:
+    # - Admin: タスクの全コメントを取得
+    # - Member: 自分のコメント + Admin作成コメントのみ取得
+    class Index
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { task_id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Comments::Index.call(params)
+        unless validation.success?
+          Rails.logger.warn "Comment index validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        task_id = validation.value[:task_id]
+
+        unless @repository.task_exists?(task_id)
+          Rails.logger.warn "Task not found for comments: task_id=#{task_id}, requested_by=#{current_account.id}"
+          return failure(["ID'#{task_id}'のタスクは存在しません"], :not_found)
+        end
+
+        comments = if current_account.role == "admin"
+          @repository.get_comments_for_admin(task_id)
+        else
+          @repository.get_comments_for_member(task_id, current_account.id)
+        end
+
+        Result.new(success?: true, comments:, errors: [], status: :ok)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Comment index DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, comments: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/comments/index.rb
+++ b/app/services/comments/index.rb
@@ -38,6 +38,9 @@ module Services
         end
 
         Result.new(success?: true, comments:, errors: [], status: :ok)
+      rescue ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Comment index lock timeout: #{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
       rescue ActiveRecord::StatementInvalid => e
         Rails.logger.error "Comment index DB error: #{e.message}"
         failure(["データベースエラーが発生しました"], :internal_server_error)

--- a/app/services/comments/repository.rb
+++ b/app/services/comments/repository.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Services
+  module Comments
+    # Comment モデルへのデータアクセスを担当するリポジトリ
+    #
+    # Service 層から直接 ActiveRecord を呼び出さないための抽象化層
+    # テスト時にモック化することで DB 非依存のテストが可能
+    class Repository
+      # Admin用: タスクの全コメントを取得（account情報含む）
+      # @param task_id [Integer] タスクID
+      # @return [ActiveRecord::Relation<Comment>]
+      def get_comments_for_admin(task_id)
+        Comment.includes(:account).where(task_id:).order(updated_at: :desc)
+      end
+
+      # Member用: 自分とAdminのコメントのみ取得（account情報含む）
+      # @param task_id [Integer] タスクID
+      # @param account_id [Integer] 閲覧者のアカウントID
+      # @return [ActiveRecord::Relation<Comment>]
+      def get_comments_for_member(task_id, account_id)
+        Comment.joins(:account)
+               .includes(:account)
+               .where(task_id:)
+               .where("comments.account_id = ? OR accounts.role = ?", account_id, "admin")
+               .order(updated_at: :desc)
+      end
+
+      # IDでコメントを検索（account情報含む）
+      # @param id [Integer] コメントID
+      # @return [Comment, nil]
+      def find_by_id(id)
+        Comment.includes(:account).find_by(id:)
+      end
+
+      # IDでコメントを悲観ロック付きで検索
+      # 同時更新を防ぐため、update/destroy 処理で使用
+      # @param id [Integer] コメントID
+      # @return [Comment, nil]
+      def find_by_id_with_lock(id)
+        Comment.lock.find_by(id:)
+      end
+
+      # 新規 Comment インスタンスを生成（未保存）
+      # @param attrs [Hash] コメント属性
+      # @return [Comment]
+      def build(attrs)
+        Comment.new(attrs)
+      end
+
+      # Comment を永続化
+      # @param comment [Comment] 保存対象のコメント
+      # @return [Boolean] 保存成功/失敗
+      def save(comment)
+        comment.save
+      end
+
+      # Comment の属性を更新
+      # @param comment [Comment] 更新対象のコメント
+      # @param attrs [Hash] 更新する属性
+      # @return [Boolean] 更新成功/失敗
+      def update(comment, attrs)
+        comment.update(attrs)
+      end
+
+      # Comment を削除
+      # @param comment [Comment] 削除対象のコメント
+      # @return [Boolean] 削除成功/失敗
+      def destroy(comment)
+        comment.destroy
+      end
+
+      # タスクが存在するか確認
+      # @param task_id [Integer] タスクID
+      # @return [Boolean]
+      def task_exists?(task_id)
+        Task.exists?(id: task_id)
+      end
+    end
+  end
+end

--- a/app/services/comments/repository.rb
+++ b/app/services/comments/repository.rb
@@ -6,11 +6,13 @@ module Services
     #
     # Service 層から直接 ActiveRecord を呼び出さないための抽象化層
     # テスト時にモック化することで DB 非依存のテストが可能
+    # N+1クエリ防止のためaccount情報をeager load
     class Repository
       # Admin用: タスクの全コメントを取得（account情報含む）
       # @param task_id [Integer] タスクID
       # @return [ActiveRecord::Relation<Comment>]
       def get_comments_for_admin(task_id)
+        Rails.logger.debug "Repository: get_comments_for_admin task_id=#{task_id}"
         Comment.includes(:account).where(task_id:).order(updated_at: :desc)
       end
 
@@ -19,6 +21,7 @@ module Services
       # @param account_id [Integer] 閲覧者のアカウントID
       # @return [ActiveRecord::Relation<Comment>]
       def get_comments_for_member(task_id, account_id)
+        Rails.logger.debug "Repository: get_comments_for_member task_id=#{task_id}, account_id=#{account_id}"
         Comment.joins(:account)
                .includes(:account)
                .where(task_id:)
@@ -30,6 +33,7 @@ module Services
       # @param id [Integer] コメントID
       # @return [Comment, nil]
       def find_by_id(id)
+        Rails.logger.debug "Repository: find_by_id id=#{id}"
         Comment.includes(:account).find_by(id:)
       end
 
@@ -38,6 +42,7 @@ module Services
       # @param id [Integer] コメントID
       # @return [Comment, nil]
       def find_by_id_with_lock(id)
+        Rails.logger.debug "Repository: find_by_id_with_lock id=#{id}"
         Comment.lock.find_by(id:)
       end
 
@@ -45,6 +50,7 @@ module Services
       # @param attrs [Hash] コメント属性
       # @return [Comment]
       def build(attrs)
+        Rails.logger.debug "Repository: build attrs=#{attrs.keys.join(', ')}"
         Comment.new(attrs)
       end
 
@@ -52,7 +58,10 @@ module Services
       # @param comment [Comment] 保存対象のコメント
       # @return [Boolean] 保存成功/失敗
       def save(comment)
-        comment.save
+        Rails.logger.debug "Repository: save comment_id=#{comment.id || 'new'}"
+        result = comment.save
+        Rails.logger.debug "Repository: save result=#{result}"
+        result
       end
 
       # Comment の属性を更新
@@ -60,20 +69,27 @@ module Services
       # @param attrs [Hash] 更新する属性
       # @return [Boolean] 更新成功/失敗
       def update(comment, attrs)
-        comment.update(attrs)
+        Rails.logger.debug "Repository: update id=#{comment.id}, attrs=#{attrs.keys.join(', ')}"
+        result = comment.update(attrs)
+        Rails.logger.debug "Repository: update result=#{result}"
+        result
       end
 
       # Comment を削除
       # @param comment [Comment] 削除対象のコメント
-      # @return [Boolean] 削除成功/失敗
+      # @return [Comment, false] 削除されたコメントオブジェクト（frozen状態）または失敗時false
       def destroy(comment)
-        comment.destroy
+        Rails.logger.debug "Repository: destroy id=#{comment.id}"
+        result = comment.destroy
+        Rails.logger.debug "Repository: destroy result=#{result.frozen? ? 'success' : 'failed'}"
+        result
       end
 
       # タスクが存在するか確認
       # @param task_id [Integer] タスクID
       # @return [Boolean]
       def task_exists?(task_id)
+        Rails.logger.debug "Repository: task_exists? task_id=#{task_id}"
         Task.exists?(id: task_id)
       end
     end

--- a/app/services/comments/result.rb
+++ b/app/services/comments/result.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Services
+  module Comments
+    # Comments サービス共通 Result
+    #
+    # 全サービスで統一して使用するResult Struct
+    # 使用しないフィールドはnilのまま
+    #
+    # @attr success? [Boolean] 処理成功/失敗
+    # @attr comment [Comment, nil] 単一リソース（show/create/update）
+    # @attr comments [Array<Comment>, nil] コレクション（index）
+    # @attr message [String, nil] 処理結果メッセージ（destroy成功時）
+    # @attr errors [Array<String>] エラーメッセージ配列
+    # @attr status [Symbol] HTTPステータス（:ok, :created, :not_found等）
+    Result = Struct.new(
+      :success?,
+      :comment,
+      :comments,
+      :message,
+      :errors,
+      :status,
+      keyword_init: true
+    )
+  end
+end

--- a/app/services/comments/show.rb
+++ b/app/services/comments/show.rb
@@ -37,6 +37,9 @@ module Services
         end
 
         Result.new(success?: true, comment:, errors: [], status: :ok)
+      rescue ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Comment show lock timeout: #{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
       rescue ActiveRecord::StatementInvalid => e
         Rails.logger.error "Comment show DB error: #{e.message}"
         failure(["データベースエラーが発生しました"], :internal_server_error)

--- a/app/services/comments/show.rb
+++ b/app/services/comments/show.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Services
+  module Comments
+    # コメント詳細取得サービス
+    #
+    # 認可ルール:
+    # - Admin: 全コメント閲覧可能
+    # - Member: 自分のコメント + Admin作成コメントのみ閲覧可能
+    class Show
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Comments::Show.call(params)
+        unless validation.success?
+          Rails.logger.warn "Comment show validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        comment = @repository.find_by_id(validation.value[:id])
+        unless comment
+          Rails.logger.warn "Comment not found: id=#{validation.value[:id]}, requested_by=#{current_account.id}"
+          return failure(["ID'#{validation.value[:id]}'のコメントは存在しません"], :not_found)
+        end
+
+        policy = ::Policies::CommentPolicy.new(current_account)
+        unless policy.can_view?(comment)
+          Rails.logger.warn "Comment view denied: id=#{comment.id}, by_account=#{current_account.id}"
+          return failure(["このコメントを閲覧する権限がありません"], :forbidden)
+        end
+
+        Result.new(success?: true, comment:, errors: [], status: :ok)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Comment show DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, comment: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/comments/update.rb
+++ b/app/services/comments/update.rb
@@ -49,7 +49,12 @@ module Services
           end
 
           # account関連を読み込み直す（Presenter用）
-          comment = @repository.find_by_id(comment.id)
+          updated_id = comment.id
+          comment = @repository.find_by_id(updated_id)
+          unless comment
+            Rails.logger.error "Comment vanished after update: id=#{updated_id}, by_account=#{current_account.id}"
+            return failure(["コメントの更新後にデータが見つかりませんでした"], :internal_server_error)
+          end
 
           Rails.logger.info "Comment updated: id=#{comment.id}, by_account=#{current_account.id}"
           return Result.new(success?: true, comment:, errors: [], status: :ok)

--- a/app/services/comments/update.rb
+++ b/app/services/comments/update.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Services
+  module Comments
+    # コメント更新サービス
+    #
+    # 認可ルール:
+    # - Admin: 全コメント更新可能
+    # - Member: 自分のコメントのみ更新可能
+    #
+    # トランザクション + 悲観ロックで同時更新を防止
+    class Update
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { id: Integer, comment: { content: String } }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Comments::Update.call(params)
+        unless validation.success?
+          Rails.logger.warn "Comment update validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        value = validation.value
+        comment_id = value[:id]
+
+        Comment.transaction do
+          comment = @repository.find_by_id_with_lock(comment_id)
+          unless comment
+            Rails.logger.warn "Comment not found during update: id=#{comment_id}, by_account=#{current_account.id}"
+            return failure(["ID'#{comment_id}'のコメントは存在しません"], :not_found)
+          end
+
+          policy = ::Policies::CommentPolicy.new(current_account)
+          unless policy.can_modify?(comment)
+            Rails.logger.warn "Comment update denied: id=#{comment.id}, by_account=#{current_account.id}"
+            return failure(["このコメントを更新する権限がありません"], :forbidden)
+          end
+
+          update_attrs = value.except(:id).compact
+          unless @repository.update(comment, update_attrs)
+            Rails.logger.warn "Comment update failed: id=#{comment.id}, errors=#{comment.errors.full_messages.join(', ')}"
+            return failure(comment.errors.full_messages, :unprocessable_entity)
+          end
+
+          # account関連を読み込み直す（Presenter用）
+          comment = @repository.find_by_id(comment.id)
+
+          Rails.logger.info "Comment updated: id=#{comment.id}, by_account=#{current_account.id}"
+          return Result.new(success?: true, comment:, errors: [], status: :ok)
+        end
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Comment update lock error: id=#{params[:id]}, error=#{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再試行してください。"], :service_unavailable)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Comment update DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, comment: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/spec/contracts/comments/create_spec.rb
+++ b/spec/contracts/comments/create_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Comments::Create, type: :model do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      it "成功を返すこと" do
+        result = described_class.call(comment: { content: "テストコメント", task_id: 1 })
+        expect(result.success?).to be true
+      end
+
+      it "正規化された値を返すこと" do
+        result = described_class.call(comment: { content: "テストコメント", task_id: "5" })
+        expect(result.value[:content]).to eq "テストコメント"
+        expect(result.value[:task_id]).to eq 5
+      end
+    end
+
+    context "contentがnilの場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(comment: { content: nil, task_id: 1 })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Content can't be blank")
+      end
+    end
+
+    context "contentが空文字の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(comment: { content: "", task_id: 1 })
+        expect(result.success?).to be false
+      end
+    end
+
+    context "contentが1000文字を超える場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(comment: { content: "a" * 1001, task_id: 1 })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Content is too long (maximum is 1000 characters)")
+      end
+    end
+
+    context "contentがちょうど1000文字の場合" do
+      it "成功を返すこと" do
+        result = described_class.call(comment: { content: "a" * 1000, task_id: 1 })
+        expect(result.success?).to be true
+      end
+    end
+
+    context "task_idがnilの場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(comment: { content: "テスト", task_id: nil })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Task can't be blank")
+      end
+    end
+
+    context "task_idが0の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(comment: { content: "テスト", task_id: 0 })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Task must be greater than 0")
+      end
+    end
+
+    context "commentパラメータがない場合" do
+      it "失敗を返すこと" do
+        result = described_class.call({})
+        expect(result.success?).to be false
+      end
+    end
+  end
+end

--- a/spec/contracts/comments/id_contract_spec.rb
+++ b/spec/contracts/comments/id_contract_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Comments::IdContract, type: :model do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      it "成功を返すこと" do
+        result = described_class.call(id: 1)
+        expect(result.success?).to be true
+      end
+
+      it "正規化されたidを返すこと" do
+        result = described_class.call(id: "5")
+        expect(result.value[:id]).to eq 5
+      end
+    end
+
+    context "idがnilの場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: nil)
+        expect(result.success?).to be false
+        expect(result.errors).to include("Id can't be blank")
+      end
+    end
+
+    context "idが空文字の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: "")
+        expect(result.success?).to be false
+      end
+    end
+
+    context "idが0の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: 0)
+        expect(result.success?).to be false
+        expect(result.errors).to include("Id must be greater than 0")
+      end
+    end
+
+    context "idが負数の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: -1)
+        expect(result.success?).to be false
+      end
+    end
+
+    context "idが文字列の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: "abc")
+        expect(result.success?).to be false
+        expect(result.errors).to include("Id is not a number")
+      end
+    end
+  end
+end

--- a/spec/contracts/comments/index_spec.rb
+++ b/spec/contracts/comments/index_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Comments::Index, type: :model do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      it "成功を返すこと" do
+        result = described_class.call(task_id: 1)
+        expect(result.success?).to be true
+      end
+
+      it "正規化されたtask_idを返すこと" do
+        result = described_class.call(task_id: "5")
+        expect(result.value[:task_id]).to eq 5
+      end
+    end
+
+    context "task_idがnilの場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(task_id: nil)
+        expect(result.success?).to be false
+        expect(result.errors).to include("Task can't be blank")
+      end
+    end
+
+    context "task_idが空文字の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(task_id: "")
+        expect(result.success?).to be false
+      end
+    end
+
+    context "task_idが0の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(task_id: 0)
+        expect(result.success?).to be false
+        expect(result.errors).to include("Task must be greater than 0")
+      end
+    end
+
+    context "task_idが負数の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(task_id: -1)
+        expect(result.success?).to be false
+      end
+    end
+
+    context "task_idが文字列の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(task_id: "abc")
+        expect(result.success?).to be false
+        expect(result.errors).to include("Task is not a number")
+      end
+    end
+  end
+end

--- a/spec/contracts/comments/update_spec.rb
+++ b/spec/contracts/comments/update_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Comments::Update, type: :model do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      it "成功を返すこと" do
+        result = described_class.call(id: 1, comment: { content: "更新コメント" })
+        expect(result.success?).to be true
+      end
+
+      it "正規化された値を返すこと" do
+        result = described_class.call(id: "5", comment: { content: "更新コメント" })
+        expect(result.value[:id]).to eq 5
+        expect(result.value[:content]).to eq "更新コメント"
+      end
+    end
+
+    context "contentがnilの場合" do
+      it "成功を返すこと（任意項目）" do
+        result = described_class.call(id: 1, comment: { content: nil })
+        expect(result.success?).to be true
+      end
+
+      it "nilはcompactで除外されること" do
+        result = described_class.call(id: 1, comment: { content: nil })
+        expect(result.value).not_to have_key(:content)
+      end
+    end
+
+    context "contentが1000文字を超える場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: 1, comment: { content: "a" * 1001 })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Content is too long (maximum is 1000 characters)")
+      end
+    end
+
+    context "idがnilの場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: nil, comment: { content: "テスト" })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Id can't be blank")
+      end
+    end
+
+    context "idが0の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: 0, comment: { content: "テスト" })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Id must be greater than 0")
+      end
+    end
+
+    context "idが文字列の場合" do
+      it "失敗を返すこと" do
+        result = described_class.call(id: "abc", comment: { content: "テスト" })
+        expect(result.success?).to be false
+        expect(result.errors).to include("Id is not a number")
+      end
+    end
+
+    context "commentパラメータがない場合" do
+      it "成功を返すこと（更新項目なし）" do
+        result = described_class.call(id: 1)
+        expect(result.success?).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::CommentPolicy, type: :model do
+  let(:admin) { create(:account, role: "admin") }
+  let(:member) { create(:account_member) }
+  let(:other_member) { create(:account_member, name: "other_member") }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area: area) }
+
+  describe "#can_view?" do
+    context "adminの場合" do
+      let(:policy) { described_class.new(admin) }
+      let(:member_comment) { create(:comment, account: member, task: task) }
+
+      it "他人のコメントを閲覧できること" do
+        expect(policy.can_view?(member_comment)).to be true
+      end
+    end
+
+    context "所有者の場合" do
+      let(:policy) { described_class.new(member) }
+      let(:own_comment) { create(:comment, account: member, task: task) }
+
+      it "自分のコメントを閲覧できること" do
+        expect(policy.can_view?(own_comment)).to be true
+      end
+    end
+
+    context "adminが作成したコメントの場合" do
+      let(:policy) { described_class.new(member) }
+      let(:admin_comment) { create(:comment, account: admin, task: task) }
+
+      it "memberでも閲覧できること" do
+        expect(policy.can_view?(admin_comment)).to be true
+      end
+    end
+
+    context "他のmemberが作成したコメントの場合" do
+      let(:policy) { described_class.new(member) }
+      let(:other_comment) { create(:comment, account: other_member, task: task) }
+
+      it "閲覧できないこと" do
+        expect(policy.can_view?(other_comment)).to be false
+      end
+    end
+
+    context "nilアカウントの場合" do
+      let(:policy) { described_class.new(nil) }
+      let(:comment) { create(:comment, account: member, task: task) }
+
+      it "閲覧できないこと" do
+        expect(policy.can_view?(comment)).to be false
+      end
+    end
+  end
+
+  describe "#can_modify?" do
+    context "adminの場合" do
+      let(:policy) { described_class.new(admin) }
+      let(:member_comment) { create(:comment, account: member, task: task) }
+
+      it "他人のコメントを編集できること" do
+        expect(policy.can_modify?(member_comment)).to be true
+      end
+    end
+
+    context "所有者の場合" do
+      let(:policy) { described_class.new(member) }
+      let(:own_comment) { create(:comment, account: member, task: task) }
+
+      it "自分のコメントを編集できること" do
+        expect(policy.can_modify?(own_comment)).to be true
+      end
+    end
+
+    context "他のmemberの場合" do
+      let(:policy) { described_class.new(member) }
+      let(:other_comment) { create(:comment, account: other_member, task: task) }
+
+      it "編集できないこと" do
+        expect(policy.can_modify?(other_comment)).to be false
+      end
+    end
+
+    context "adminが作成したコメントの場合" do
+      let(:policy) { described_class.new(member) }
+      let(:admin_comment) { create(:comment, account: admin, task: task) }
+
+      it "memberは編集できないこと" do
+        expect(policy.can_modify?(admin_comment)).to be false
+      end
+    end
+
+    context "nilアカウントの場合" do
+      let(:policy) { described_class.new(nil) }
+      let(:comment) { create(:comment, account: member, task: task) }
+
+      it "編集できないこと" do
+        expect(policy.can_modify?(comment)).to be false
+      end
+    end
+  end
+end

--- a/spec/presenters/comment_presenter_spec.rb
+++ b/spec/presenters/comment_presenter_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Presenters::CommentPresenter, type: :model do
+  let(:admin) { create(:account, role: "admin") }
+  let(:member) { create(:account_member) }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area: area) }
+
+  describe ".render_comment" do
+    context "有効なコメントの場合" do
+      let(:comment) { create(:comment, account: member, task: task, content: "テストコメント") }
+
+      it "正しい形式を返すこと" do
+        result = described_class.render_comment(comment)
+        expect(result[:id]).to eq comment.id
+        expect(result[:content]).to eq "テストコメント"
+        expect(result[:task_id]).to eq task.id
+        expect(result[:account_id]).to eq member.id
+        expect(result[:account_name]).to eq member.name
+        expect(result[:account_role]).to eq "member"
+        expect(result[:updated_at]).to be_present
+      end
+
+      it "updated_atがISO8601形式であること" do
+        result = described_class.render_comment(comment)
+        expect { Time.iso8601(result[:updated_at]) }.not_to raise_error
+      end
+    end
+
+    context "nilの場合" do
+      it "nilを返すこと" do
+        result = described_class.render_comment(nil)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe ".render_comments" do
+    context "有効なコメント配列の場合" do
+      let(:comment1) { create(:comment, account: admin, task: task, content: "Admin comment") }
+      let(:comment2) { create(:comment, account: member, task: task, content: "Member comment") }
+
+      it "全てのコメントを変換すること" do
+        result = described_class.render_comments([comment1, comment2])
+        expect(result.length).to eq 2
+        expect(result[0][:content]).to eq "Admin comment"
+        expect(result[1][:content]).to eq "Member comment"
+      end
+    end
+
+    context "空配列の場合" do
+      it "空配列を返すこと" do
+        result = described_class.render_comments([])
+        expect(result).to eq []
+      end
+    end
+
+    context "nilの場合" do
+      it "空配列を返すこと" do
+        result = described_class.render_comments(nil)
+        expect(result).to eq []
+      end
+    end
+  end
+end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -3,187 +3,307 @@
 require "rails_helper"
 
 RSpec.describe "Api::Comments", type: :request do
+  let(:admin) { create(:account) }
+  let(:member) { create(:account_member) }
+  let(:other_member) { create(:account_member, name: "other_member") }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area_id: area.id) }
+
+  let(:admin_headers) { { "Authorization" => "Bearer #{JsonWebToken.encode(account_id: admin.id)}" } }
+  let(:member_headers) { { "Authorization" => "Bearer #{JsonWebToken.encode(account_id: member.id)}" } }
+  let(:other_member_headers) { { "Authorization" => "Bearer #{JsonWebToken.encode(account_id: other_member.id)}" } }
+
   describe "GET /api/comments" do
     before do
-      @admin = create(:account)
-      @member = create(:account_member)
-      @area = create(:area)
-      @task = create(:task, area_id: @area.id)
-      @admin_comment = create(:comment, account: @admin, task: @task, content: "管理者コメント")
-      @member_comment = create(:comment, account: @member, task: @task, content: "メンバーコメント")
+      @admin_comment = create(:comment, account: admin, task: task, content: "管理者コメント")
+      @member_comment = create(:comment, account: member, task: task, content: "メンバーコメント")
+      @other_comment = create(:comment, account: other_member, task: task, content: "他メンバーコメント")
+    end
+
+    context "認証なしの場合" do
+      it "Status 401が返ってくること" do
+        get "/api/comments", params: { taskId: task.id }
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     context "adminユーザーがアクセスする場合" do
       it "Status 200が返ってくること" do
-        get "/api/comments", params: { taskId: @task.id, accountId: @admin.id }
+        get "/api/comments", params: { taskId: task.id }, headers: admin_headers
         expect(response).to have_http_status(:ok)
       end
 
       it "全てのコメントが返ってくること" do
-        get "/api/comments", params: { taskId: @task.id, accountId: @admin.id }
+        get "/api/comments", params: { taskId: task.id }, headers: admin_headers
         json_response = JSON.parse(response.body)
-        expect(json_response.length).to eq(2)
+        expect(json_response.length).to eq(3)
       end
 
       it "正しい形式のデータが返ってくること" do
-        get "/api/comments", params: { taskId: @task.id, accountId: @admin.id }
+        get "/api/comments", params: { taskId: task.id }, headers: admin_headers
         json_response = JSON.parse(response.body)
         expect(json_response[0]).to have_key("id")
         expect(json_response[0]).to have_key("content")
-        expect(json_response[0]).to have_key("name")
+        expect(json_response[0]).to have_key("account_name")
+        expect(json_response[0]).to have_key("account_role")
+        expect(json_response[0]).to have_key("updated_at")
       end
     end
 
     context "memberユーザーがアクセスする場合" do
       it "Status 200が返ってくること" do
-        get "/api/comments", params: { taskId: @task.id, accountId: @member.id }
+        get "/api/comments", params: { taskId: task.id }, headers: member_headers
         expect(response).to have_http_status(:ok)
       end
 
       it "自分とadminのコメントのみが返ってくること" do
-        other_member = create(:account_member, name: "other_member")
-        create(:comment, account: other_member, task: @task, content: "他メンバーコメント")
-
-        get "/api/comments", params: { taskId: @task.id, accountId: @member.id }
+        get "/api/comments", params: { taskId: task.id }, headers: member_headers
         json_response = JSON.parse(response.body)
         # 自分のコメント + adminのコメントのみ（他メンバーは含まない）
         expect(json_response.length).to eq(2)
+        ids = json_response.map { |c| c["id"] }
+        expect(ids).to include(@admin_comment.id, @member_comment.id)
+        expect(ids).not_to include(@other_comment.id)
+      end
+    end
+
+    context "taskIdがない場合" do
+      it "Status 422が返ってくること" do
+        get "/api/comments", params: {}, headers: admin_headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "存在しないtaskIdの場合" do
+      it "Status 404が返ってくること" do
+        get "/api/comments", params: { taskId: 999999 }, headers: admin_headers
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
 
   describe "GET /api/comments/:id" do
-    before do
-      @member = create(:account_member)
-      @area = create(:area)
-      @task = create(:task, area_id: @area.id)
-      @comment = create(:comment, account: @member, task: @task, content: "テストコメント")
+    let(:member_comment) { create(:comment, account: member, task: task, content: "テストコメント") }
+
+    context "認証なしの場合" do
+      it "Status 401が返ってくること" do
+        get "/api/comments/#{member_comment.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
-    context "存在するコメントの場合" do
+    context "所有者がアクセスする場合" do
       it "Status 200が返ってくること" do
-        get "/api/comments/#{@comment.id}"
+        get "/api/comments/#{member_comment.id}", headers: member_headers
         expect(response).to have_http_status(:ok)
       end
 
       it "正しいデータが返ってくること" do
-        get "/api/comments/#{@comment.id}"
+        get "/api/comments/#{member_comment.id}", headers: member_headers
         json_response = JSON.parse(response.body)
-        expect(json_response["id"]).to eq(@comment.id)
+        expect(json_response["id"]).to eq(member_comment.id)
         expect(json_response["content"]).to eq("テストコメント")
+      end
+    end
+
+    context "adminがアクセスする場合" do
+      it "Status 200が返ってくること" do
+        get "/api/comments/#{member_comment.id}", headers: admin_headers
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "他のmemberがアクセスする場合" do
+      it "Status 403が返ってくること" do
+        get "/api/comments/#{member_comment.id}", headers: other_member_headers
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
     context "存在しないコメントの場合" do
       it "Status 404が返ってくること" do
-        get "/api/comments/999999"
+        get "/api/comments/999999", headers: admin_headers
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "無効なIDフォーマットの場合" do
+      it "文字列IDでStatus 422が返ってくること" do
+        get "/api/comments/abc", headers: admin_headers
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
 
   describe "POST /api/comments" do
-    before do
-      @member = create(:account_member)
-      @area = create(:area)
-      @task = create(:task, area_id: @area.id)
+    context "認証なしの場合" do
+      it "Status 401が返ってくること" do
+        post "/api/comments", params: { comment: { content: "新規コメント", task_id: task.id } }
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        post "/api/comments", params: { comment: { content: "新規コメント", task_id: @task.id, account_id: @member.id } }
-        expect(response).to have_http_status(:ok)
+      it "Status 201が返ってくること" do
+        post "/api/comments", params: { comment: { content: "新規コメント", task_id: task.id } }, headers: member_headers
+        expect(response).to have_http_status(:created)
       end
 
       it "コメントが作成されること" do
         expect {
-          post "/api/comments", params: { comment: { content: "新規コメント", task_id: @task.id, account_id: @member.id } }
+          post "/api/comments", params: { comment: { content: "新規コメント", task_id: task.id } }, headers: member_headers
         }.to change(Comment, :count).by(1)
       end
 
       it "作成されたデータが返ってくること" do
-        post "/api/comments", params: { comment: { content: "新規コメント", task_id: @task.id, account_id: @member.id } }
+        post "/api/comments", params: { comment: { content: "新規コメント", task_id: task.id } }, headers: member_headers
         json_response = JSON.parse(response.body)
         expect(json_response["content"]).to eq("新規コメント")
+        expect(json_response["account_id"]).to eq(member.id)
+        expect(json_response["account_name"]).to eq(member.name)
       end
     end
 
-    context "無効なパラメータの場合" do
-      # Note: Comment modelにcontentのバリデーションがないため、空でも保存される
-      # 将来的にバリデーション追加時はこのテストを更新する
-      it "contentが空の場合でも保存されること（バリデーションなし）" do
-        post "/api/comments", params: { comment: { content: "", task_id: @task.id, account_id: @member.id } }
-        expect(response).to have_http_status(:ok)
+    context "contentが空の場合" do
+      it "Status 422が返ってくること" do
+        post "/api/comments", params: { comment: { content: "", task_id: task.id } }, headers: member_headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "task_idがない場合" do
+      it "Status 422が返ってくること" do
+        post "/api/comments", params: { comment: { content: "テスト" } }, headers: member_headers
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "存在しないtask_idの場合" do
+      it "Status 404が返ってくること" do
+        post "/api/comments", params: { comment: { content: "テスト", task_id: 999999 } }, headers: member_headers
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
 
   describe "PUT /api/comments/:id" do
-    before do
-      @member = create(:account_member)
-      @area = create(:area)
-      @task = create(:task, area_id: @area.id)
-      @comment = create(:comment, account: @member, task: @task, content: "元のコメント")
+    let(:member_comment) { create(:comment, account: member, task: task, content: "元のコメント") }
+
+    context "認証なしの場合" do
+      it "Status 401が返ってくること" do
+        put "/api/comments/#{member_comment.id}", params: { comment: { content: "更新" } }
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
-    context "有効なパラメータの場合" do
+    context "所有者が更新する場合" do
       it "Status 200が返ってくること" do
-        put "/api/comments/#{@comment.id}", params: { comment: { content: "更新後のコメント" } }
+        put "/api/comments/#{member_comment.id}", params: { comment: { content: "更新後のコメント" } }, headers: member_headers
         expect(response).to have_http_status(:ok)
       end
 
       it "更新されたデータが返ってくること" do
-        put "/api/comments/#{@comment.id}", params: { comment: { content: "更新後のコメント" } }
+        put "/api/comments/#{member_comment.id}", params: { comment: { content: "更新後のコメント" } }, headers: member_headers
         json_response = JSON.parse(response.body)
         expect(json_response["content"]).to eq("更新後のコメント")
       end
 
       it "DBが更新されていること" do
-        put "/api/comments/#{@comment.id}", params: { comment: { content: "更新後のコメント" } }
-        @comment.reload
-        expect(@comment.content).to eq("更新後のコメント")
+        put "/api/comments/#{member_comment.id}", params: { comment: { content: "更新後のコメント" } }, headers: member_headers
+        member_comment.reload
+        expect(member_comment.content).to eq("更新後のコメント")
+      end
+    end
+
+    context "adminが更新する場合" do
+      it "Status 200が返ってくること" do
+        put "/api/comments/#{member_comment.id}", params: { comment: { content: "Admin更新" } }, headers: admin_headers
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "他のmemberが更新する場合" do
+      it "Status 403が返ってくること" do
+        put "/api/comments/#{member_comment.id}", params: { comment: { content: "更新" } }, headers: other_member_headers
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
     context "存在しないコメントの場合" do
       it "Status 404が返ってくること" do
-        put "/api/comments/999999", params: { comment: { content: "更新" } }
+        put "/api/comments/999999", params: { comment: { content: "更新" } }, headers: admin_headers
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "無効なIDフォーマットの場合" do
+      it "文字列IDでStatus 422が返ってくること" do
+        put "/api/comments/abc", params: { comment: { content: "更新" } }, headers: admin_headers
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
 
   describe "DELETE /api/comments/:id" do
-    before do
-      @member = create(:account_member)
-      @area = create(:area)
-      @task = create(:task, area_id: @area.id)
-      @comment = create(:comment, account: @member, task: @task)
+    context "認証なしの場合" do
+      let!(:comment) { create(:comment, account: member, task: task) }
+
+      it "Status 401が返ってくること" do
+        delete "/api/comments/#{comment.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
-    context "存在するコメントの場合" do
+    context "所有者が削除する場合" do
+      let!(:member_comment) { create(:comment, account: member, task: task) }
+
       it "Status 200が返ってくること" do
-        delete "/api/comments/#{@comment.id}"
+        delete "/api/comments/#{member_comment.id}", headers: member_headers
         expect(response).to have_http_status(:ok)
       end
 
       it "成功メッセージが返ってくること" do
-        delete "/api/comments/#{@comment.id}"
+        delete "/api/comments/#{member_comment.id}", headers: member_headers
         json_response = JSON.parse(response.body)
-        expect(json_response["message"]).to eq("complete")
+        expect(json_response["message"]).to eq("deleted")
       end
 
       it "コメントが削除されること" do
         expect {
-          delete "/api/comments/#{@comment.id}"
+          delete "/api/comments/#{member_comment.id}", headers: member_headers
         }.to change(Comment, :count).by(-1)
+      end
+    end
+
+    context "adminが削除する場合" do
+      let!(:member_comment) { create(:comment, account: member, task: task) }
+
+      it "Status 200が返ってくること" do
+        delete "/api/comments/#{member_comment.id}", headers: admin_headers
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "他のmemberが削除する場合" do
+      let!(:member_comment) { create(:comment, account: member, task: task) }
+
+      it "Status 403が返ってくること" do
+        delete "/api/comments/#{member_comment.id}", headers: other_member_headers
+        expect(response).to have_http_status(:forbidden)
       end
     end
 
     context "存在しないコメントの場合" do
       it "Status 404が返ってくること" do
-        delete "/api/comments/999999"
+        delete "/api/comments/999999", headers: admin_headers
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "無効なIDフォーマットの場合" do
+      it "文字列IDでStatus 422が返ってくること" do
+        delete "/api/comments/abc", headers: admin_headers
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/services/comments/create_spec.rb
+++ b/spec/services/comments/create_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Comments::Create, type: :model do
+  let(:admin) { create(:account, role: "admin") }
+  let(:member) { create(:account_member) }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area: area) }
+
+  describe "#call" do
+    context "認証されていない場合" do
+      it "unauthorizedを返すこと" do
+        result = described_class.new.call({ comment: { content: "テスト", task_id: task.id } }, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unauthorized
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "バリデーションエラーの場合" do
+      it "contentがnilの場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ comment: { content: nil, task_id: task.id } }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+
+      it "task_idがnilの場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ comment: { content: "テスト", task_id: nil } }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+    end
+
+    context "タスクが存在しない場合" do
+      it "not_foundを返すこと" do
+        result = described_class.new.call({ comment: { content: "テスト", task_id: 999999 } }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :not_found
+      end
+    end
+
+    context "有効なパラメータの場合" do
+      it "成功を返すこと" do
+        result = described_class.new.call({ comment: { content: "テストコメント", task_id: task.id } }, member)
+        expect(result.success?).to be true
+        expect(result.status).to eq :created
+      end
+
+      it "コメントが作成されること" do
+        expect {
+          described_class.new.call({ comment: { content: "テストコメント", task_id: task.id } }, member)
+        }.to change(Comment, :count).by(1)
+      end
+
+      it "account_idがcurrent_accountから設定されること" do
+        result = described_class.new.call({ comment: { content: "テストコメント", task_id: task.id } }, member)
+        expect(result.comment.account_id).to eq member.id
+      end
+
+      it "作成されたコメントがaccount情報を含むこと" do
+        result = described_class.new.call({ comment: { content: "テストコメント", task_id: task.id } }, member)
+        expect(result.comment.account).not_to be_nil
+        expect(result.comment.account.name).to eq member.name
+      end
+    end
+
+    context "adminユーザーの場合" do
+      it "成功を返すこと" do
+        result = described_class.new.call({ comment: { content: "Adminコメント", task_id: task.id } }, admin)
+        expect(result.success?).to be true
+        expect(result.comment.account_id).to eq admin.id
+      end
+    end
+  end
+end

--- a/spec/services/comments/create_spec.rb
+++ b/spec/services/comments/create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Services::Comments::Create, type: :model do
   let(:admin) { create(:account, role: "admin") }
   let(:member) { create(:account_member) }
   let(:area) { create(:area) }
-  let(:task) { create(:task, area: area) }
+  let(:task) { create(:task, area:) }
 
   describe "#call" do
     context "認証されていない場合" do
@@ -70,6 +70,86 @@ RSpec.describe Services::Comments::Create, type: :model do
         result = described_class.new.call({ comment: { content: "Adminコメント", task_id: task.id } }, admin)
         expect(result.success?).to be true
         expect(result.comment.account_id).to eq admin.id
+      end
+    end
+
+    context "デッドロックが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+      let(:mock_comment) { instance_double(Comment, id: 1) }
+
+      before do
+        allow(mock_repository).to receive(:task_exists?).and_return(true)
+        allow(mock_repository).to receive(:build).and_return(mock_comment)
+        allow(mock_repository).to receive(:save).and_raise(ActiveRecord::Deadlocked)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { comment: { content: "テスト", task_id: task.id } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+        expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+      end
+    end
+
+    context "LockWaitTimeoutが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+      let(:mock_comment) { instance_double(Comment, id: 1) }
+
+      before do
+        allow(mock_repository).to receive(:task_exists?).and_return(true)
+        allow(mock_repository).to receive(:build).and_return(mock_comment)
+        allow(mock_repository).to receive(:save).and_raise(ActiveRecord::LockWaitTimeout)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { comment: { content: "テスト", task_id: task.id } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+        expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+      end
+    end
+
+    context "InvalidForeignKeyが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+      let(:mock_comment) { instance_double(Comment, id: 1) }
+
+      before do
+        allow(mock_repository).to receive(:task_exists?).and_return(true)
+        allow(mock_repository).to receive(:build).and_return(mock_comment)
+        allow(mock_repository).to receive(:save).and_raise(ActiveRecord::InvalidForeignKey)
+      end
+
+      it "conflictを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { comment: { content: "テスト", task_id: task.id } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :conflict
+        expect(result.errors).to include("関連するタスクまたはアカウントが存在しません")
+      end
+    end
+
+    context "StatementInvalidが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+      let(:mock_comment) { instance_double(Comment, id: 1) }
+
+      before do
+        allow(mock_repository).to receive(:task_exists?).and_return(true)
+        allow(mock_repository).to receive(:build).and_return(mock_comment)
+        allow(mock_repository).to receive(:save).and_raise(ActiveRecord::StatementInvalid)
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { comment: { content: "テスト", task_id: task.id } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :internal_server_error
+        expect(result.errors).to include("データベースエラーが発生しました")
       end
     end
   end

--- a/spec/services/comments/create_spec.rb
+++ b/spec/services/comments/create_spec.rb
@@ -133,6 +133,26 @@ RSpec.describe Services::Comments::Create, type: :model do
       end
     end
 
+    context "RecordNotUniqueが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+      let(:mock_comment) { instance_double(Comment, id: 1) }
+
+      before do
+        allow(mock_repository).to receive(:task_exists?).and_return(true)
+        allow(mock_repository).to receive(:build).and_return(mock_comment)
+        allow(mock_repository).to receive(:save).and_raise(ActiveRecord::RecordNotUnique)
+      end
+
+      it "conflictを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { comment: { content: "テスト", task_id: task.id } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :conflict
+        expect(result.errors).to include("このコメントは既に存在します")
+      end
+    end
+
     context "StatementInvalidが発生した場合" do
       let(:mock_repository) { instance_double(Services::Comments::Repository) }
       let(:mock_comment) { instance_double(Comment, id: 1) }

--- a/spec/services/comments/destroy_spec.rb
+++ b/spec/services/comments/destroy_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Services::Comments::Destroy, type: :model do
   let(:member) { create(:account_member) }
   let(:other_member) { create(:account_member, name: "other_member") }
   let(:area) { create(:area) }
-  let(:task) { create(:task, area: area) }
+  let(:task) { create(:task, area:) }
 
   describe "#call" do
     context "認証されていない場合" do
-      let(:comment) { create(:comment, account: member, task: task) }
+      let(:comment) { create(:comment, account: member, task:) }
 
       it "unauthorizedを返すこと" do
         result = described_class.new.call({ id: comment.id }, nil)
@@ -44,7 +44,7 @@ RSpec.describe Services::Comments::Destroy, type: :model do
     end
 
     context "所有者の場合" do
-      let!(:own_comment) { create(:comment, account: member, task: task) }
+      let!(:own_comment) { create(:comment, account: member, task:) }
 
       it "削除できること" do
         result = described_class.new.call({ id: own_comment.id }, member)
@@ -61,7 +61,7 @@ RSpec.describe Services::Comments::Destroy, type: :model do
     end
 
     context "adminの場合" do
-      let!(:member_comment) { create(:comment, account: member, task: task) }
+      let!(:member_comment) { create(:comment, account: member, task:) }
 
       it "他人のコメントを削除できること" do
         result = described_class.new.call({ id: member_comment.id }, admin)
@@ -71,7 +71,7 @@ RSpec.describe Services::Comments::Destroy, type: :model do
     end
 
     context "他のmemberの場合" do
-      let!(:other_comment) { create(:comment, account: other_member, task: task) }
+      let!(:other_comment) { create(:comment, account: other_member, task:) }
 
       it "削除できないこと" do
         result = described_class.new.call({ id: other_comment.id }, member)
@@ -82,7 +82,7 @@ RSpec.describe Services::Comments::Destroy, type: :model do
     end
 
     context "デッドロックが発生した場合" do
-      let(:comment) { create(:comment, account: member, task: task) }
+      let(:comment) { create(:comment, account: member, task:) }
       let(:mock_repository) { instance_double(Services::Comments::Repository) }
 
       before do
@@ -93,6 +93,39 @@ RSpec.describe Services::Comments::Destroy, type: :model do
         result = described_class.new(repository: mock_repository).call({ id: comment.id }, member)
         expect(result.success?).to be false
         expect(result.status).to eq :service_unavailable
+      end
+    end
+
+    context "LockWaitTimeoutが発生した場合" do
+      let(:comment) { create(:comment, account: member, task:) }
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::LockWaitTimeout)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call({ id: comment.id }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+        expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+      end
+    end
+
+    context "StatementInvalidが発生した場合" do
+      let(:comment) { create(:comment, account: member, task:) }
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id_with_lock).and_return(comment)
+        allow(mock_repository).to receive(:destroy).and_raise(ActiveRecord::StatementInvalid)
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = described_class.new(repository: mock_repository).call({ id: comment.id }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :internal_server_error
+        expect(result.errors).to include("データベースエラーが発生しました")
       end
     end
   end

--- a/spec/services/comments/destroy_spec.rb
+++ b/spec/services/comments/destroy_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Comments::Destroy, type: :model do
+  let(:admin) { create(:account, role: "admin") }
+  let(:member) { create(:account_member) }
+  let(:other_member) { create(:account_member, name: "other_member") }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area: area) }
+
+  describe "#call" do
+    context "認証されていない場合" do
+      let(:comment) { create(:comment, account: member, task: task) }
+
+      it "unauthorizedを返すこと" do
+        result = described_class.new.call({ id: comment.id }, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unauthorized
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "バリデーションエラーの場合" do
+      it "idがnilの場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ id: nil }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+
+      it "idが無効な場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ id: "abc" }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+    end
+
+    context "コメントが存在しない場合" do
+      it "not_foundを返すこと" do
+        result = described_class.new.call({ id: 999999 }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :not_found
+      end
+    end
+
+    context "所有者の場合" do
+      let!(:own_comment) { create(:comment, account: member, task: task) }
+
+      it "削除できること" do
+        result = described_class.new.call({ id: own_comment.id }, member)
+        expect(result.success?).to be true
+        expect(result.status).to eq :ok
+        expect(result.message).to eq "deleted"
+      end
+
+      it "コメントが削除されること" do
+        expect {
+          described_class.new.call({ id: own_comment.id }, member)
+        }.to change(Comment, :count).by(-1)
+      end
+    end
+
+    context "adminの場合" do
+      let!(:member_comment) { create(:comment, account: member, task: task) }
+
+      it "他人のコメントを削除できること" do
+        result = described_class.new.call({ id: member_comment.id }, admin)
+        expect(result.success?).to be true
+        expect(result.message).to eq "deleted"
+      end
+    end
+
+    context "他のmemberの場合" do
+      let!(:other_comment) { create(:comment, account: other_member, task: task) }
+
+      it "削除できないこと" do
+        result = described_class.new.call({ id: other_comment.id }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :forbidden
+        expect(result.errors).to include("このコメントを削除する権限がありません")
+      end
+    end
+
+    context "デッドロックが発生した場合" do
+      let(:comment) { create(:comment, account: member, task: task) }
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::Deadlocked)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call({ id: comment.id }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+      end
+    end
+  end
+end

--- a/spec/services/comments/index_spec.rb
+++ b/spec/services/comments/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Services::Comments::Index, type: :model do
   let(:admin) { create(:account, role: "admin") }
   let(:member) { create(:account_member) }
   let(:area) { create(:area) }
-  let(:task) { create(:task, area: area) }
+  let(:task) { create(:task, area:) }
 
   describe "#call" do
     context "認証されていない場合" do
@@ -42,8 +42,8 @@ RSpec.describe Services::Comments::Index, type: :model do
 
     context "adminユーザーの場合" do
       before do
-        @admin_comment = create(:comment, account: admin, task: task, content: "Admin comment")
-        @member_comment = create(:comment, account: member, task: task, content: "Member comment")
+        @admin_comment = create(:comment, account: admin, task:, content: "Admin comment")
+        @member_comment = create(:comment, account: member, task:, content: "Member comment")
       end
 
       it "成功を返すこと" do
@@ -62,9 +62,9 @@ RSpec.describe Services::Comments::Index, type: :model do
       let(:other_member) { create(:account_member, name: "other_member") }
 
       before do
-        @admin_comment = create(:comment, account: admin, task: task, content: "Admin comment")
-        @member_comment = create(:comment, account: member, task: task, content: "Member comment")
-        @other_comment = create(:comment, account: other_member, task: task, content: "Other comment")
+        @admin_comment = create(:comment, account: admin, task:, content: "Admin comment")
+        @member_comment = create(:comment, account: member, task:, content: "Member comment")
+        @other_comment = create(:comment, account: other_member, task:, content: "Other comment")
       end
 
       it "成功を返すこと" do
@@ -94,6 +94,23 @@ RSpec.describe Services::Comments::Index, type: :model do
         result = described_class.new(repository: mock_repository).call({ task_id: task.id }, admin)
         expect(result.success?).to be false
         expect(result.status).to eq :internal_server_error
+        expect(result.errors).to include("データベースエラーが発生しました")
+      end
+    end
+
+    context "LockWaitTimeoutが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:task_exists?).and_return(true)
+        allow(mock_repository).to receive(:get_comments_for_admin).and_raise(ActiveRecord::LockWaitTimeout)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call({ task_id: task.id }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+        expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
       end
     end
   end

--- a/spec/services/comments/index_spec.rb
+++ b/spec/services/comments/index_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Comments::Index, type: :model do
+  let(:admin) { create(:account, role: "admin") }
+  let(:member) { create(:account_member) }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area: area) }
+
+  describe "#call" do
+    context "認証されていない場合" do
+      it "unauthorizedを返すこと" do
+        result = described_class.new.call({ task_id: task.id }, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unauthorized
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "バリデーションエラーの場合" do
+      it "task_idがnilの場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ task_id: nil }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+
+      it "task_idが無効な場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ task_id: "abc" }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+    end
+
+    context "タスクが存在しない場合" do
+      it "not_foundを返すこと" do
+        result = described_class.new.call({ task_id: 999999 }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :not_found
+      end
+    end
+
+    context "adminユーザーの場合" do
+      before do
+        @admin_comment = create(:comment, account: admin, task: task, content: "Admin comment")
+        @member_comment = create(:comment, account: member, task: task, content: "Member comment")
+      end
+
+      it "成功を返すこと" do
+        result = described_class.new.call({ task_id: task.id }, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq :ok
+      end
+
+      it "全てのコメントを取得すること" do
+        result = described_class.new.call({ task_id: task.id }, admin)
+        expect(result.comments.length).to eq 2
+      end
+    end
+
+    context "memberユーザーの場合" do
+      let(:other_member) { create(:account_member, name: "other_member") }
+
+      before do
+        @admin_comment = create(:comment, account: admin, task: task, content: "Admin comment")
+        @member_comment = create(:comment, account: member, task: task, content: "Member comment")
+        @other_comment = create(:comment, account: other_member, task: task, content: "Other comment")
+      end
+
+      it "成功を返すこと" do
+        result = described_class.new.call({ task_id: task.id }, member)
+        expect(result.success?).to be true
+        expect(result.status).to eq :ok
+      end
+
+      it "自分とadminのコメントのみを取得すること" do
+        result = described_class.new.call({ task_id: task.id }, member)
+        expect(result.comments.length).to eq 2
+        comment_ids = result.comments.map(&:id)
+        expect(comment_ids).to include(@admin_comment.id, @member_comment.id)
+        expect(comment_ids).not_to include(@other_comment.id)
+      end
+    end
+
+    context "DBエラーが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:task_exists?).and_return(true)
+        allow(mock_repository).to receive(:get_comments_for_admin).and_raise(ActiveRecord::StatementInvalid)
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = described_class.new(repository: mock_repository).call({ task_id: task.id }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :internal_server_error
+      end
+    end
+  end
+end

--- a/spec/services/comments/show_spec.rb
+++ b/spec/services/comments/show_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Comments::Show, type: :model do
+  let(:admin) { create(:account, role: "admin") }
+  let(:member) { create(:account_member) }
+  let(:other_member) { create(:account_member, name: "other_member") }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area: area) }
+
+  describe "#call" do
+    context "認証されていない場合" do
+      let(:comment) { create(:comment, account: member, task: task) }
+
+      it "unauthorizedを返すこと" do
+        result = described_class.new.call({ id: comment.id }, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unauthorized
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "バリデーションエラーの場合" do
+      it "idがnilの場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ id: nil }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+
+      it "idが無効な場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ id: "abc" }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+    end
+
+    context "コメントが存在しない場合" do
+      it "not_foundを返すこと" do
+        result = described_class.new.call({ id: 999999 }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :not_found
+      end
+    end
+
+    context "adminユーザーの場合" do
+      let(:member_comment) { create(:comment, account: member, task: task) }
+
+      it "他のユーザーのコメントを閲覧できること" do
+        result = described_class.new.call({ id: member_comment.id }, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq :ok
+        expect(result.comment.id).to eq member_comment.id
+      end
+    end
+
+    context "memberユーザーの場合" do
+      context "自分のコメントの場合" do
+        let(:own_comment) { create(:comment, account: member, task: task) }
+
+        it "閲覧できること" do
+          result = described_class.new.call({ id: own_comment.id }, member)
+          expect(result.success?).to be true
+          expect(result.status).to eq :ok
+        end
+      end
+
+      context "adminのコメントの場合" do
+        let(:admin_comment) { create(:comment, account: admin, task: task) }
+
+        it "閲覧できること" do
+          result = described_class.new.call({ id: admin_comment.id }, member)
+          expect(result.success?).to be true
+          expect(result.status).to eq :ok
+        end
+      end
+
+      context "他のmemberのコメントの場合" do
+        let(:other_comment) { create(:comment, account: other_member, task: task) }
+
+        it "閲覧できないこと" do
+          result = described_class.new.call({ id: other_comment.id }, member)
+          expect(result.success?).to be false
+          expect(result.status).to eq :forbidden
+          expect(result.errors).to include("このコメントを閲覧する権限がありません")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/comments/show_spec.rb
+++ b/spec/services/comments/show_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Services::Comments::Show, type: :model do
   let(:member) { create(:account_member) }
   let(:other_member) { create(:account_member, name: "other_member") }
   let(:area) { create(:area) }
-  let(:task) { create(:task, area: area) }
+  let(:task) { create(:task, area:) }
 
   describe "#call" do
     context "認証されていない場合" do
-      let(:comment) { create(:comment, account: member, task: task) }
+      let(:comment) { create(:comment, account: member, task:) }
 
       it "unauthorizedを返すこと" do
         result = described_class.new.call({ id: comment.id }, nil)
@@ -44,7 +44,7 @@ RSpec.describe Services::Comments::Show, type: :model do
     end
 
     context "adminユーザーの場合" do
-      let(:member_comment) { create(:comment, account: member, task: task) }
+      let(:member_comment) { create(:comment, account: member, task:) }
 
       it "他のユーザーのコメントを閲覧できること" do
         result = described_class.new.call({ id: member_comment.id }, admin)
@@ -56,7 +56,7 @@ RSpec.describe Services::Comments::Show, type: :model do
 
     context "memberユーザーの場合" do
       context "自分のコメントの場合" do
-        let(:own_comment) { create(:comment, account: member, task: task) }
+        let(:own_comment) { create(:comment, account: member, task:) }
 
         it "閲覧できること" do
           result = described_class.new.call({ id: own_comment.id }, member)
@@ -66,7 +66,7 @@ RSpec.describe Services::Comments::Show, type: :model do
       end
 
       context "adminのコメントの場合" do
-        let(:admin_comment) { create(:comment, account: admin, task: task) }
+        let(:admin_comment) { create(:comment, account: admin, task:) }
 
         it "閲覧できること" do
           result = described_class.new.call({ id: admin_comment.id }, member)
@@ -76,7 +76,7 @@ RSpec.describe Services::Comments::Show, type: :model do
       end
 
       context "他のmemberのコメントの場合" do
-        let(:other_comment) { create(:comment, account: other_member, task: task) }
+        let(:other_comment) { create(:comment, account: other_member, task:) }
 
         it "閲覧できないこと" do
           result = described_class.new.call({ id: other_comment.id }, member)
@@ -84,6 +84,36 @@ RSpec.describe Services::Comments::Show, type: :model do
           expect(result.status).to eq :forbidden
           expect(result.errors).to include("このコメントを閲覧する権限がありません")
         end
+      end
+    end
+
+    context "LockWaitTimeoutが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id).and_raise(ActiveRecord::LockWaitTimeout)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call({ id: 1 }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+        expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+      end
+    end
+
+    context "StatementInvalidが発生した場合" do
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id).and_raise(ActiveRecord::StatementInvalid)
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = described_class.new(repository: mock_repository).call({ id: 1 }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :internal_server_error
+        expect(result.errors).to include("データベースエラーが発生しました")
       end
     end
   end

--- a/spec/services/comments/update_spec.rb
+++ b/spec/services/comments/update_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Services::Comments::Update, type: :model do
   let(:member) { create(:account_member) }
   let(:other_member) { create(:account_member, name: "other_member") }
   let(:area) { create(:area) }
-  let(:task) { create(:task, area: area) }
+  let(:task) { create(:task, area:) }
 
   describe "#call" do
     context "認証されていない場合" do
-      let(:comment) { create(:comment, account: member, task: task) }
+      let(:comment) { create(:comment, account: member, task:) }
 
       it "unauthorizedを返すこと" do
         result = described_class.new.call({ id: comment.id, comment: { content: "更新" } }, nil)
@@ -29,7 +29,7 @@ RSpec.describe Services::Comments::Update, type: :model do
       end
 
       it "contentが長すぎる場合、unprocessable_entityを返すこと" do
-        comment = create(:comment, account: member, task: task)
+        comment = create(:comment, account: member, task:)
         result = described_class.new.call({ id: comment.id, comment: { content: "a" * 1001 } }, member)
         expect(result.success?).to be false
         expect(result.status).to eq :unprocessable_entity
@@ -45,7 +45,7 @@ RSpec.describe Services::Comments::Update, type: :model do
     end
 
     context "所有者の場合" do
-      let(:own_comment) { create(:comment, account: member, task: task, content: "元のコメント") }
+      let(:own_comment) { create(:comment, account: member, task:, content: "元のコメント") }
 
       it "更新できること" do
         result = described_class.new.call({ id: own_comment.id, comment: { content: "更新コメント" } }, member)
@@ -56,7 +56,7 @@ RSpec.describe Services::Comments::Update, type: :model do
     end
 
     context "adminの場合" do
-      let(:member_comment) { create(:comment, account: member, task: task, content: "元のコメント") }
+      let(:member_comment) { create(:comment, account: member, task:, content: "元のコメント") }
 
       it "他人のコメントを更新できること" do
         result = described_class.new.call({ id: member_comment.id, comment: { content: "Admin更新" } }, admin)
@@ -66,7 +66,7 @@ RSpec.describe Services::Comments::Update, type: :model do
     end
 
     context "他のmemberの場合" do
-      let(:other_comment) { create(:comment, account: other_member, task: task) }
+      let(:other_comment) { create(:comment, account: other_member, task:) }
 
       it "更新できないこと" do
         result = described_class.new.call({ id: other_comment.id, comment: { content: "更新" } }, member)
@@ -77,7 +77,7 @@ RSpec.describe Services::Comments::Update, type: :model do
     end
 
     context "デッドロックが発生した場合" do
-      let(:comment) { create(:comment, account: member, task: task) }
+      let(:comment) { create(:comment, account: member, task:) }
       let(:mock_repository) { instance_double(Services::Comments::Repository) }
 
       before do
@@ -90,6 +90,43 @@ RSpec.describe Services::Comments::Update, type: :model do
         )
         expect(result.success?).to be false
         expect(result.status).to eq :service_unavailable
+      end
+    end
+
+    context "LockWaitTimeoutが発生した場合" do
+      let(:comment) { create(:comment, account: member, task:) }
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::LockWaitTimeout)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { id: comment.id, comment: { content: "更新" } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+        expect(result.errors).to include("サーバーが混雑しています。しばらくしてから再試行してください。")
+      end
+    end
+
+    context "StatementInvalidが発生した場合" do
+      let(:comment) { create(:comment, account: member, task:) }
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id_with_lock).and_return(comment)
+        allow(mock_repository).to receive(:update).and_raise(ActiveRecord::StatementInvalid)
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { id: comment.id, comment: { content: "更新" } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :internal_server_error
+        expect(result.errors).to include("データベースエラーが発生しました")
       end
     end
   end

--- a/spec/services/comments/update_spec.rb
+++ b/spec/services/comments/update_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Comments::Update, type: :model do
+  let(:admin) { create(:account, role: "admin") }
+  let(:member) { create(:account_member) }
+  let(:other_member) { create(:account_member, name: "other_member") }
+  let(:area) { create(:area) }
+  let(:task) { create(:task, area: area) }
+
+  describe "#call" do
+    context "認証されていない場合" do
+      let(:comment) { create(:comment, account: member, task: task) }
+
+      it "unauthorizedを返すこと" do
+        result = described_class.new.call({ id: comment.id, comment: { content: "更新" } }, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unauthorized
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "バリデーションエラーの場合" do
+      it "idがnilの場合、unprocessable_entityを返すこと" do
+        result = described_class.new.call({ id: nil, comment: { content: "更新" } }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+
+      it "contentが長すぎる場合、unprocessable_entityを返すこと" do
+        comment = create(:comment, account: member, task: task)
+        result = described_class.new.call({ id: comment.id, comment: { content: "a" * 1001 } }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :unprocessable_entity
+      end
+    end
+
+    context "コメントが存在しない場合" do
+      it "not_foundを返すこと" do
+        result = described_class.new.call({ id: 999999, comment: { content: "更新" } }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq :not_found
+      end
+    end
+
+    context "所有者の場合" do
+      let(:own_comment) { create(:comment, account: member, task: task, content: "元のコメント") }
+
+      it "更新できること" do
+        result = described_class.new.call({ id: own_comment.id, comment: { content: "更新コメント" } }, member)
+        expect(result.success?).to be true
+        expect(result.status).to eq :ok
+        expect(result.comment.content).to eq "更新コメント"
+      end
+    end
+
+    context "adminの場合" do
+      let(:member_comment) { create(:comment, account: member, task: task, content: "元のコメント") }
+
+      it "他人のコメントを更新できること" do
+        result = described_class.new.call({ id: member_comment.id, comment: { content: "Admin更新" } }, admin)
+        expect(result.success?).to be true
+        expect(result.comment.content).to eq "Admin更新"
+      end
+    end
+
+    context "他のmemberの場合" do
+      let(:other_comment) { create(:comment, account: other_member, task: task) }
+
+      it "更新できないこと" do
+        result = described_class.new.call({ id: other_comment.id, comment: { content: "更新" } }, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq :forbidden
+        expect(result.errors).to include("このコメントを更新する権限がありません")
+      end
+    end
+
+    context "デッドロックが発生した場合" do
+      let(:comment) { create(:comment, account: member, task: task) }
+      let(:mock_repository) { instance_double(Services::Comments::Repository) }
+
+      before do
+        allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::Deadlocked)
+      end
+
+      it "service_unavailableを返すこと" do
+        result = described_class.new(repository: mock_repository).call(
+          { id: comment.id, comment: { content: "更新" } }, member
+        )
+        expect(result.success?).to be false
+        expect(result.status).to eq :service_unavailable
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Comments コントローラーを4層アーキテクチャに移行（Phase 3）
- セキュリティ強化: 認証必須化、認可チェック追加、パラメータ偽装防止
- 可視性ルール実装: Member は自分+Admin コメントのみ閲覧可

## 変更ファイル (28 files, +1756/-90)

### 新規作成
| カテゴリ | ファイル |
|---------|---------|
| Contract | `app/contracts/comments/index.rb` |
| Contract | `app/contracts/comments/id_contract.rb` |
| Contract | `app/contracts/comments/show.rb` |
| Contract | `app/contracts/comments/destroy.rb` |
| Contract | `app/contracts/comments/create.rb` |
| Contract | `app/contracts/comments/update.rb` |
| Service | `app/services/comments/result.rb` |
| Service | `app/services/comments/repository.rb` |
| Service | `app/services/comments/index.rb` |
| Service | `app/services/comments/show.rb` |
| Service | `app/services/comments/create.rb` |
| Service | `app/services/comments/update.rb` |
| Service | `app/services/comments/destroy.rb` |
| Policy | `app/policies/comment_policy.rb` |
| Presenter | `app/presenters/comment_presenter.rb` |
| Test | `spec/contracts/comments/*_spec.rb` (4ファイル) |
| Test | `spec/services/comments/*_spec.rb` (5ファイル) |
| Test | `spec/policies/comment_policy_spec.rb` |
| Test | `spec/presenters/comment_presenter_spec.rb` |

### 修正
- `app/controllers/api/comments_controller.rb`
- `spec/requests/api/comments_spec.rb`

## 認可ルール

| 操作 | admin | member (owner) | member (other) |
|------|-------|----------------|----------------|
| index | ✅ 全件 | ✅ 自分+Admin | ✅ 自分+Admin |
| show | ✅ | ✅ 自分/Admin | ❌ |
| create | ✅ | ✅ | ✅ |
| update | ✅ | ✅ 自分のみ | ❌ |
| destroy | ✅ | ✅ 自分のみ | ❌ |

## 破壊的変更

| 変更 | Before | After |
|------|--------|-------|
| 認証 | なし | 全エンドポイント必須 (401) |
| Create accountId | パラメータ指定 | current_account.id 使用 |
| Update/Destroy | 誰でも可 | 所有者/Admin のみ (403) |
| 可視性 | 全件表示 | Member は自分+Admin コメントのみ |

## Test plan
- [x] Contract テスト (4ファイル)
- [x] Service テスト (5ファイル)
- [x] Policy テスト
- [x] Presenter テスト
- [x] Request テスト (認証・認可・可視性)
- [x] RuboCop: No offenses
- [x] RSpec: 1323 examples, 0 failures