### PR TITLE
refactor: Tags コントローラーを4層アーキテクチャに移行

### DIFF
--- a/app/contracts/tags/create.rb
+++ b/app/contracts/tags/create.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tags
+    # タグ作成の入力検証
+    class Create
+      include ActiveModel::Model
+
+      attr_accessor :name
+
+      validates :name, presence: true, length: { maximum: 32 }
+
+      def self.call(params)
+        contract = new(name: params.dig(:tag, :name) || params[:name])
+        if contract.valid?
+          ::Contracts::Result.new(success?: true, value: { name: contract.name }, errors: [])
+        else
+          ::Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+    end
+  end
+end

--- a/app/contracts/tags/destroy.rb
+++ b/app/contracts/tags/destroy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tags
+    # タグ削除の入力検証
+    class Destroy < IdContract
+    end
+  end
+end

--- a/app/contracts/tags/id_contract.rb
+++ b/app/contracts/tags/id_contract.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tags
+    # タグID検証の基底クラス
+    #
+    # Show, Destroy で継承して使用
+    class IdContract
+      include ActiveModel::Model
+
+      attr_accessor :id
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+
+      def self.call(params)
+        contract = new(id: params[:id])
+        if contract.valid?
+          ::Contracts::Result.new(success?: true, value: { id: contract.id.to_i }, errors: [])
+        else
+          ::Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+    end
+  end
+end

--- a/app/contracts/tags/show.rb
+++ b/app/contracts/tags/show.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tags
+    # タグ詳細取得の入力検証
+    class Show < IdContract
+    end
+  end
+end

--- a/app/contracts/tags/update.rb
+++ b/app/contracts/tags/update.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Tags
+    # タグ更新の入力検証
+    class Update
+      include ActiveModel::Model
+
+      attr_accessor :id, :name
+
+      validates :id, presence: true
+      validates :id, numericality: { only_integer: true, greater_than: 0 }, if: -> { id.present? }
+      validates :name, length: { maximum: 32 }, allow_nil: true
+
+      def self.call(params)
+        contract = new(
+          id: params[:id],
+          name: params.dig(:tag, :name) || params[:name]
+        )
+        if contract.valid?
+          ::Contracts::Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          ::Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { id: id.to_i, name: }.compact
+      end
+    end
+  end
+end

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -1,37 +1,47 @@
 # frozen_string_literal: true
 
 class Api::TagsController < ApplicationController
-  def index
-    tags = Tag.all
+  before_action :authenticated?
 
-    render json: tags
+  def index
+    result = ::Services::Tags::Index.new.call(@current_account)
+    render_result(result) { ::Presenters::TagPresenter.render_tags(result.tags) }
+  end
+
+  def show
+    result = ::Services::Tags::Show.new.call(show_params, @current_account)
+    render_result(result) { ::Presenters::TagPresenter.render_tag(result.tag) }
   end
 
   def create
-    tag = Tag.new(create_params)
-
-    if tag.save
-      render json: tag
-    else
-      render json: { message: tag.errors, status: 422 }, status: :unprocessable_entity
-    end
+    result = ::Services::Tags::Create.new.call(create_params, @current_account)
+    render_result(result) { ::Presenters::TagPresenter.render_tag(result.tag) }
   end
 
   def update
-    tag = Tag.find(params[:id])
-    tag.update(create_params)
-
-    render json: tag
+    result = ::Services::Tags::Update.new.call(update_params, @current_account)
+    render_result(result) { ::Presenters::TagPresenter.render_tag(result.tag) }
   end
 
   def destroy
-    tag = Tag.find(params[:id])
-
-    tag.destroy
+    result = ::Services::Tags::Destroy.new.call(destroy_params, @current_account)
+    render_result(result) { { message: result.message } }
   end
 
   private
+    def show_params
+      { id: params[:id] }
+    end
+
     def create_params
-      params.require(:tag).permit(:name)
+      { tag: params.require(:tag).permit(:name) }
+    end
+
+    def update_params
+      { id: params[:id], tag: params.require(:tag).permit(:name) }
+    end
+
+    def destroy_params
+      { id: params[:id] }
     end
 end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -14,11 +14,7 @@ module Policies
     # タグの作成・更新・削除は admin のみ許可
     # @return [Boolean]
     def admin_only?
-      if @account.nil?
-        Rails.logger.warn "TagPolicy: account is nil during admin_only? check"
-        return false
-      end
-      @account.role == "admin"
+      @account&.role == "admin"
     end
   end
 end

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Policies
+  # タグ操作の認可ポリシー
+  #
+  # 認可ルール:
+  # - 閲覧(index/show): 全認証ユーザー
+  # - 作成/更新/削除: admin のみ
+  class TagPolicy
+    def initialize(account)
+      @account = account
+    end
+
+    # タグの作成・更新・削除は admin のみ許可
+    # @return [Boolean]
+    def admin_only?
+      if @account.nil?
+        Rails.logger.warn "TagPolicy: account is nil during admin_only? check"
+        return false
+      end
+      @account.role == "admin"
+    end
+  end
+end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -6,12 +6,10 @@ module Presenters
     class << self
       # 単一タグをレスポンス形式に変換
       # @param tag [Tag] タグオブジェクト
-      # @return [Hash, nil]
+      # @return [Hash]
+      # @raise [ArgumentError] tag が nil の場合
       def render_tag(tag)
-        if tag.nil?
-          Rails.logger.warn "TagPresenter.render_tag received nil tag"
-          return nil
-        end
+        raise ArgumentError, "TagPresenter.render_tag received nil tag" if tag.nil?
 
         { id: tag.id, name: tag.name }
       end
@@ -19,11 +17,9 @@ module Presenters
       # タグ一覧をレスポンス形式に変換
       # @param tags [Array<Tag>] タグ配列
       # @return [Array<Hash>]
+      # @raise [ArgumentError] tags が nil の場合
       def render_tags(tags)
-        if tags.nil?
-          Rails.logger.warn "TagPresenter.render_tags received nil tags"
-          return []
-        end
+        raise ArgumentError, "TagPresenter.render_tags received nil tags" if tags.nil?
 
         tags.map { |tag| render_tag(tag) }
       end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Presenters
+  # タグのレスポンス整形を担当
+  class TagPresenter
+    class << self
+      # 単一タグをレスポンス形式に変換
+      # @param tag [Tag] タグオブジェクト
+      # @return [Hash, nil]
+      def render_tag(tag)
+        if tag.nil?
+          Rails.logger.warn "TagPresenter.render_tag received nil tag"
+          return nil
+        end
+
+        { id: tag.id, name: tag.name }
+      end
+
+      # タグ一覧をレスポンス形式に変換
+      # @param tags [Array<Tag>] タグ配列
+      # @return [Array<Hash>]
+      def render_tags(tags)
+        if tags.nil?
+          Rails.logger.warn "TagPresenter.render_tags received nil tags"
+          return []
+        end
+
+        tags.map { |tag| render_tag(tag) }
+      end
+    end
+  end
+end

--- a/app/services/tags/create.rb
+++ b/app/services/tags/create.rb
@@ -10,7 +10,7 @@ module Services
         @repository = repository
       end
 
-      # @param params [Hash] { tag: { name: String } }
+      # @param params [Hash] { tag: { name: String } } または { name: String }
       # @param current_account [Account, nil] 現在のログインユーザー
       # @return [Result]
       def call(params, current_account)

--- a/app/services/tags/create.rb
+++ b/app/services/tags/create.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Services
+  module Tags
+    # タグ作成サービス
+    #
+    # 認可: admin のみ
+    class Create
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { tag: { name: String } }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Tags::Create.call(params)
+        unless validation.success?
+          Rails.logger.warn "Tag create validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        policy = ::Policies::TagPolicy.new(current_account)
+        unless policy.admin_only?
+          Rails.logger.warn "Tag create unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
+
+        tag = @repository.build(name: validation.value[:name])
+        unless @repository.save(tag)
+          Rails.logger.warn "Tag create failed: name=#{validation.value[:name]}, errors=#{tag.errors.full_messages.join(', ')}, by_account=#{current_account.id}"
+          return failure(tag.errors.full_messages, :unprocessable_entity)
+        end
+
+        Rails.logger.info "Tag created: id=#{tag.id}, name=#{tag.name}, by_account=#{current_account.id}"
+        Result.new(success?: true, tag:, errors: [], status: :created)
+      rescue ActiveRecord::RecordNotUnique => e
+        Rails.logger.error "Tag create uniqueness error: #{e.message}"
+        failure(["このタグは既に存在します"], :conflict)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Tag create DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, tag: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/tags/destroy.rb
+++ b/app/services/tags/destroy.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Services
+  module Tags
+    # タグ削除サービス
+    #
+    # 認可: admin のみ
+    # 同時更新防止: 悲観ロック
+    # FK制約: tag_accounts 関連があれば削除不可
+    class Destroy
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Tags::Destroy.call(params)
+        unless validation.success?
+          Rails.logger.warn "Tag destroy validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        policy = ::Policies::TagPolicy.new(current_account)
+        unless policy.admin_only?
+          Rails.logger.warn "Tag destroy unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
+
+        tag_id = validation.value[:id]
+
+        Tag.transaction do
+          tag = @repository.find_by_id_with_lock(tag_id)
+          unless tag
+            Rails.logger.warn "Tag not found during destroy: id=#{tag_id}, by_account=#{current_account.id}"
+            return failure(["ID'#{tag_id}'のタグは存在しません"], :not_found)
+          end
+
+          unless @repository.destroy(tag)
+            Rails.logger.error "Tag destroy failed (callbacks): id=#{tag.id}, errors=#{tag.errors.full_messages.join(', ')}"
+            return failure(["タグの削除に失敗しました"], :unprocessable_entity)
+          end
+
+          Rails.logger.info "Tag destroyed: id=#{tag_id}, by_account=#{current_account.id}"
+          Result.new(success?: true, message: "deleted", errors: [], status: :ok)
+        end
+      rescue ActiveRecord::InvalidForeignKey => e
+        Rails.logger.error "Tag destroy failed (FK constraint): id=#{tag_id}, error=#{e.message}"
+        failure(["このタグにはアカウントが関連付けられているため削除できません"], :conflict)
+      rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
+        Rails.logger.error "Tag destroy lock timeout: #{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再度お試しください"], :service_unavailable)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Tag destroy DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, message: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/tags/destroy.rb
+++ b/app/services/tags/destroy.rb
@@ -6,16 +6,18 @@ module Services
     #
     # 認可: admin のみ
     # 同時更新防止: 悲観ロック
-    # FK制約: tag_accounts 関連があれば削除不可
+    # FK制約: tag_accounts または tag_tasks 関連があれば削除不可
     class Destroy
       def initialize(repository: Repository.new)
         @repository = repository
       end
 
-      # @param params [Hash] { id: Integer }
+      # @param params [Hash] { id: String|Integer } IDパラメータ
       # @param current_account [Account, nil] 現在のログインユーザー
       # @return [Result]
       def call(params, current_account)
+        tag_id = nil # rescue block用に事前初期化
+
         return failure(["認証が必要です"], :unauthorized) if current_account.nil?
 
         validation = ::Contracts::Tags::Destroy.call(params)
@@ -48,8 +50,8 @@ module Services
           Result.new(success?: true, message: "deleted", errors: [], status: :ok)
         end
       rescue ActiveRecord::InvalidForeignKey => e
-        Rails.logger.error "Tag destroy failed (FK constraint): id=#{tag_id}, error=#{e.message}"
-        failure(["このタグにはアカウントが関連付けられているため削除できません"], :conflict)
+        Rails.logger.error "Tag destroy failed (FK constraint): id=#{tag_id || 'unknown'}, error=#{e.message}"
+        failure(["このタグにはアカウントまたはタスクが関連付けられているため削除できません"], :conflict)
       rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
         Rails.logger.error "Tag destroy lock timeout: #{e.message}"
         failure(["サーバーが混雑しています。しばらくしてから再度お試しください"], :service_unavailable)

--- a/app/services/tags/index.rb
+++ b/app/services/tags/index.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Services
+  module Tags
+    # タグ一覧取得サービス
+    #
+    # 認可: 全認証ユーザー
+    class Index
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        tags = @repository.all_tags
+        Result.new(success?: true, tags:, errors: [], status: :ok)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Tag index DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, tags: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/tags/repository.rb
+++ b/app/services/tags/repository.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Services
+  module Tags
+    # タグのDBアクセスを担当
+    #
+    # 全メソッドにdebugログを出力
+    class Repository
+      def all_tags
+        Rails.logger.debug "Repository: all_tags"
+        Tag.select(:id, :name)
+      end
+
+      def find_by_id(id)
+        Rails.logger.debug "Repository: find_by_id id=#{id}"
+        Tag.find_by(id:)
+      end
+
+      def find_by_id_with_lock(id)
+        Rails.logger.debug "Repository: find_by_id_with_lock id=#{id}"
+        Tag.lock.find_by(id:)
+      end
+
+      def build(attrs)
+        Rails.logger.debug "Repository: build attrs=#{attrs.keys.join(', ')}"
+        Tag.new(attrs)
+      end
+
+      def save(tag)
+        Rails.logger.debug "Repository: save id=#{tag.id || 'new'}"
+        result = tag.save
+        Rails.logger.debug "Repository: save result=#{result}"
+        result
+      end
+
+      def update(tag, attrs)
+        Rails.logger.debug "Repository: update id=#{tag.id}, attrs=#{attrs.keys.join(', ')}"
+        result = tag.update(attrs)
+        Rails.logger.debug "Repository: update result=#{result}"
+        result
+      end
+
+      def destroy(tag)
+        Rails.logger.debug "Repository: destroy id=#{tag.id}"
+        result = tag.destroy
+        Rails.logger.debug "Repository: destroy result=#{result.frozen? ? 'success' : 'failed'}"
+        result
+      end
+    end
+  end
+end

--- a/app/services/tags/repository.rb
+++ b/app/services/tags/repository.rb
@@ -40,11 +40,15 @@ module Services
         result
       end
 
+      # タグを削除
+      # @param tag [Tag] 削除対象のタグ
+      # @return [Boolean] 削除成功/失敗
       def destroy(tag)
         Rails.logger.debug "Repository: destroy id=#{tag.id}"
-        result = tag.destroy
-        Rails.logger.debug "Repository: destroy result=#{result.frozen? ? 'success' : 'failed'}"
-        result
+        tag.destroy
+        destroyed = tag.destroyed?
+        Rails.logger.debug "Repository: destroy result=#{destroyed ? 'success' : 'failed'}"
+        destroyed
       end
     end
   end

--- a/app/services/tags/result.rb
+++ b/app/services/tags/result.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Services
+  module Tags
+    # タグサービスの結果オブジェクト
+    Result = Struct.new(
+      :success?,
+      :tag,
+      :tags,
+      :message,
+      :errors,
+      :status,
+      keyword_init: true
+    )
+  end
+end

--- a/app/services/tags/show.rb
+++ b/app/services/tags/show.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Services
+  module Tags
+    # タグ詳細取得サービス
+    #
+    # 認可: 全認証ユーザー
+    class Show
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Tags::Show.call(params)
+        unless validation.success?
+          Rails.logger.warn "Tag show validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        tag = @repository.find_by_id(validation.value[:id])
+        unless tag
+          Rails.logger.warn "Tag not found: id=#{validation.value[:id]}, requested_by=#{current_account.id}"
+          return failure(["ID'#{validation.value[:id]}'のタグは存在しません"], :not_found)
+        end
+
+        Result.new(success?: true, tag:, errors: [], status: :ok)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Tag show DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, tag: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/tags/show.rb
+++ b/app/services/tags/show.rb
@@ -10,7 +10,7 @@ module Services
         @repository = repository
       end
 
-      # @param params [Hash] { id: Integer }
+      # @param params [Hash] { id: String|Integer } IDパラメータ
       # @param current_account [Account, nil] 現在のログインユーザー
       # @return [Result]
       def call(params, current_account)

--- a/app/services/tags/update.rb
+++ b/app/services/tags/update.rb
@@ -11,7 +11,7 @@ module Services
         @repository = repository
       end
 
-      # @param params [Hash] { id: Integer, tag: { name: String } }
+      # @param params [Hash] { id: String|Integer, tag: { name: String } }
       # @param current_account [Account, nil] 現在のログインユーザー
       # @return [Result]
       def call(params, current_account)

--- a/app/services/tags/update.rb
+++ b/app/services/tags/update.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Services
+  module Tags
+    # タグ更新サービス
+    #
+    # 認可: admin のみ
+    # 同時更新防止: 悲観ロック
+    class Update
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { id: Integer, tag: { name: String } }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        validation = ::Contracts::Tags::Update.call(params)
+        unless validation.success?
+          Rails.logger.warn "Tag update validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        policy = ::Policies::TagPolicy.new(current_account)
+        unless policy.admin_only?
+          Rails.logger.warn "Tag update unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
+
+        value = validation.value
+        update_attrs = value.except(:id).compact
+
+        Tag.transaction do
+          tag = @repository.find_by_id_with_lock(value[:id])
+          unless tag
+            Rails.logger.warn "Tag not found during update: id=#{value[:id]}, by_account=#{current_account.id}"
+            return failure(["ID'#{value[:id]}'のタグは存在しません"], :not_found)
+          end
+
+          unless @repository.update(tag, update_attrs)
+            Rails.logger.warn "Tag update failed: id=#{tag.id}, errors=#{tag.errors.full_messages.join(', ')}"
+            return failure(tag.errors.full_messages, :unprocessable_entity)
+          end
+
+          Rails.logger.info "Tag updated: id=#{tag.id}, by_account=#{current_account.id}"
+          Result.new(success?: true, tag:, errors: [], status: :ok)
+        end
+      rescue ActiveRecord::LockWaitTimeout, ActiveRecord::Deadlocked => e
+        Rails.logger.error "Tag update lock timeout: #{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再度お試しください"], :service_unavailable)
+      rescue ActiveRecord::RecordNotUnique => e
+        Rails.logger.error "Tag update uniqueness error: #{e.message}"
+        failure(["このタグは既に存在します"], :conflict)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Tag update DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def failure(errors, status)
+          Result.new(success?: false, tag: nil, errors:, status:)
+        end
+    end
+  end
+end

--- a/spec/contracts/tags/create_spec.rb
+++ b/spec/contracts/tags/create_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tags::Create, type: :contract do
+  describe ".call" do
+    context "正常系" do
+      it "有効なnameで成功すること" do
+        result = described_class.call({ name: "緊急" })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq("緊急")
+        expect(result.errors).to be_empty
+      end
+
+      it "params[:tag][:name]形式で成功すること" do
+        result = described_class.call({ tag: { name: "重要" } })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq("重要")
+      end
+
+      it "32文字のnameで成功すること" do
+        name = "a" * 32
+        result = described_class.call({ name: })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq(name)
+      end
+    end
+
+    context "異常系" do
+      it "nameがnilの場合、失敗すること" do
+        result = described_class.call({ name: nil })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "nameが空文字の場合、失敗すること" do
+        result = described_class.call({ name: "" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "nameが33文字の場合、失敗すること" do
+        name = "a" * 33
+        result = described_class.call({ name: })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/contracts/tags/id_contract_spec.rb
+++ b/spec/contracts/tags/id_contract_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tags::IdContract, type: :contract do
+  describe ".call" do
+    context "正常系" do
+      it "正の整数IDで成功すること" do
+        result = described_class.call({ id: 1 })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.errors).to be_empty
+      end
+
+      it "文字列形式の正の整数IDで成功すること" do
+        result = described_class.call({ id: "123" })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(123)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "異常系" do
+      it "idがnilの場合、失敗すること" do
+        result = described_class.call({ id: nil })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが空文字の場合、失敗すること" do
+        result = described_class.call({ id: "" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが0の場合、失敗すること" do
+        result = described_class.call({ id: 0 })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが負数の場合、失敗すること" do
+        result = described_class.call({ id: -1 })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが数値でない文字列の場合、失敗すること" do
+        result = described_class.call({ id: "abc" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが小数の場合、失敗すること" do
+        result = described_class.call({ id: 1.5 })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/contracts/tags/update_spec.rb
+++ b/spec/contracts/tags/update_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Tags::Update, type: :contract do
+  describe ".call" do
+    context "正常系" do
+      it "idとnameで成功すること" do
+        result = described_class.call({ id: 1, name: "緊急" })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.value[:name]).to eq("緊急")
+        expect(result.errors).to be_empty
+      end
+
+      it "params[:tag][:name]形式で成功すること" do
+        result = described_class.call({ id: 1, tag: { name: "重要" } })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.value[:name]).to eq("重要")
+      end
+
+      it "nameがnilでも成功すること" do
+        result = described_class.call({ id: 1, name: nil })
+
+        expect(result.success?).to be true
+        expect(result.value[:id]).to eq(1)
+        expect(result.value).not_to have_key(:name)
+      end
+
+      it "32文字のnameで成功すること" do
+        name = "a" * 32
+        result = described_class.call({ id: 1, name: })
+
+        expect(result.success?).to be true
+        expect(result.value[:name]).to eq(name)
+      end
+    end
+
+    context "異常系" do
+      it "idがnilの場合、失敗すること" do
+        result = described_class.call({ id: nil, name: "緊急" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが0の場合、失敗すること" do
+        result = described_class.call({ id: 0, name: "緊急" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "idが負数の場合、失敗すること" do
+        result = described_class.call({ id: -1, name: "緊急" })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+
+      it "nameが33文字の場合、失敗すること" do
+        name = "a" * 33
+        result = described_class.call({ id: 1, name: })
+
+        expect(result.success?).to be false
+        expect(result.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Policies::CommentPolicy, type: :model do
   let(:member) { create(:account_member) }
   let(:other_member) { create(:account_member, name: "other_member") }
   let(:area) { create(:area) }
-  let(:task) { create(:task, area: area) }
+  let(:task) { create(:task, area:) }
 
   describe "#can_view?" do
     context "adminの場合" do
       let(:policy) { described_class.new(admin) }
-      let(:member_comment) { create(:comment, account: member, task: task) }
+      let(:member_comment) { create(:comment, account: member, task:) }
 
       it "他人のコメントを閲覧できること" do
         expect(policy.can_view?(member_comment)).to be true
@@ -21,7 +21,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "所有者の場合" do
       let(:policy) { described_class.new(member) }
-      let(:own_comment) { create(:comment, account: member, task: task) }
+      let(:own_comment) { create(:comment, account: member, task:) }
 
       it "自分のコメントを閲覧できること" do
         expect(policy.can_view?(own_comment)).to be true
@@ -30,7 +30,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "adminが作成したコメントの場合" do
       let(:policy) { described_class.new(member) }
-      let(:admin_comment) { create(:comment, account: admin, task: task) }
+      let(:admin_comment) { create(:comment, account: admin, task:) }
 
       it "memberでも閲覧できること" do
         expect(policy.can_view?(admin_comment)).to be true
@@ -39,7 +39,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "他のmemberが作成したコメントの場合" do
       let(:policy) { described_class.new(member) }
-      let(:other_comment) { create(:comment, account: other_member, task: task) }
+      let(:other_comment) { create(:comment, account: other_member, task:) }
 
       it "閲覧できないこと" do
         expect(policy.can_view?(other_comment)).to be false
@@ -48,7 +48,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "nilアカウントの場合" do
       let(:policy) { described_class.new(nil) }
-      let(:comment) { create(:comment, account: member, task: task) }
+      let(:comment) { create(:comment, account: member, task:) }
 
       it "閲覧できないこと" do
         expect(policy.can_view?(comment)).to be false
@@ -59,7 +59,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
   describe "#can_modify?" do
     context "adminの場合" do
       let(:policy) { described_class.new(admin) }
-      let(:member_comment) { create(:comment, account: member, task: task) }
+      let(:member_comment) { create(:comment, account: member, task:) }
 
       it "他人のコメントを編集できること" do
         expect(policy.can_modify?(member_comment)).to be true
@@ -68,7 +68,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "所有者の場合" do
       let(:policy) { described_class.new(member) }
-      let(:own_comment) { create(:comment, account: member, task: task) }
+      let(:own_comment) { create(:comment, account: member, task:) }
 
       it "自分のコメントを編集できること" do
         expect(policy.can_modify?(own_comment)).to be true
@@ -77,7 +77,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "他のmemberの場合" do
       let(:policy) { described_class.new(member) }
-      let(:other_comment) { create(:comment, account: other_member, task: task) }
+      let(:other_comment) { create(:comment, account: other_member, task:) }
 
       it "編集できないこと" do
         expect(policy.can_modify?(other_comment)).to be false
@@ -86,7 +86,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "adminが作成したコメントの場合" do
       let(:policy) { described_class.new(member) }
-      let(:admin_comment) { create(:comment, account: admin, task: task) }
+      let(:admin_comment) { create(:comment, account: admin, task:) }
 
       it "memberは編集できないこと" do
         expect(policy.can_modify?(admin_comment)).to be false
@@ -95,7 +95,7 @@ RSpec.describe Policies::CommentPolicy, type: :model do
 
     context "nilアカウントの場合" do
       let(:policy) { described_class.new(nil) }
-      let(:comment) { create(:comment, account: member, task: task) }
+      let(:comment) { create(:comment, account: member, task:) }
 
       it "編集できないこと" do
         expect(policy.can_modify?(comment)).to be false

--- a/spec/policies/tag_policy_spec.rb
+++ b/spec/policies/tag_policy_spec.rb
@@ -28,11 +28,6 @@ RSpec.describe Policies::TagPolicy, type: :policy do
       it "false を返すこと" do
         expect(policy.admin_only?).to be false
       end
-
-      it "警告ログを出力すること" do
-        expect(Rails.logger).to receive(:warn).with(/account is nil/)
-        policy.admin_only?
-      end
     end
 
     context "role が nil の場合" do

--- a/spec/policies/tag_policy_spec.rb
+++ b/spec/policies/tag_policy_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Policies::TagPolicy, type: :policy do
+  describe "#admin_only?" do
+    context "admin アカウントの場合" do
+      let(:account) { build(:account, role: "admin") }
+      let(:policy) { described_class.new(account) }
+
+      it "true を返すこと" do
+        expect(policy.admin_only?).to be true
+      end
+    end
+
+    context "member アカウントの場合" do
+      let(:account) { build(:account, role: "member") }
+      let(:policy) { described_class.new(account) }
+
+      it "false を返すこと" do
+        expect(policy.admin_only?).to be false
+      end
+    end
+
+    context "nil アカウントの場合" do
+      let(:policy) { described_class.new(nil) }
+
+      it "false を返すこと" do
+        expect(policy.admin_only?).to be false
+      end
+
+      it "警告ログを出力すること" do
+        expect(Rails.logger).to receive(:warn).with(/account is nil/)
+        policy.admin_only?
+      end
+    end
+
+    context "role が nil の場合" do
+      let(:account) { build(:account, role: nil) }
+      let(:policy) { described_class.new(account) }
+
+      it "false を返すこと" do
+        expect(policy.admin_only?).to be false
+      end
+    end
+  end
+end

--- a/spec/presenters/comment_presenter_spec.rb
+++ b/spec/presenters/comment_presenter_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Presenters::CommentPresenter, type: :model do
   let(:admin) { create(:account, role: "admin") }
   let(:member) { create(:account_member) }
   let(:area) { create(:area) }
-  let(:task) { create(:task, area: area) }
+  let(:task) { create(:task, area:) }
 
   describe ".render_comment" do
     context "有効なコメントの場合" do
-      let(:comment) { create(:comment, account: member, task: task, content: "テストコメント") }
+      let(:comment) { create(:comment, account: member, task:, content: "テストコメント") }
 
       it "正しい形式を返すこと" do
         result = described_class.render_comment(comment)
@@ -39,8 +39,8 @@ RSpec.describe Presenters::CommentPresenter, type: :model do
 
   describe ".render_comments" do
     context "有効なコメント配列の場合" do
-      let(:comment1) { create(:comment, account: admin, task: task, content: "Admin comment") }
-      let(:comment2) { create(:comment, account: member, task: task, content: "Member comment") }
+      let(:comment1) { create(:comment, account: admin, task:, content: "Admin comment") }
+      let(:comment2) { create(:comment, account: member, task:, content: "Member comment") }
 
       it "全てのコメントを変換すること" do
         result = described_class.render_comments([comment1, comment2])

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Presenters::TagPresenter, type: :model do
+  describe ".render_tag" do
+    context "有効なタグの場合" do
+      let(:tag) { create(:tag, name: "緊急") }
+
+      it "正しいハッシュ構造を返すこと" do
+        result = described_class.render_tag(tag)
+
+        expect(result).to eq({ id: tag.id, name: "緊急" })
+      end
+    end
+
+    context "nilの場合" do
+      it "nilを返すこと" do
+        result = described_class.render_tag(nil)
+
+        expect(result).to be_nil
+      end
+
+      it "警告ログを出力すること" do
+        expect(Rails.logger).to receive(:warn).with(/received nil tag/)
+        described_class.render_tag(nil)
+      end
+    end
+  end
+
+  describe ".render_tags" do
+    context "有効なタグ配列の場合" do
+      let!(:tag1) { create(:tag, name: "緊急") }
+      let!(:tag2) { create(:tag, name: "重要") }
+
+      it "ハッシュ配列を返すこと" do
+        result = described_class.render_tags([tag1, tag2])
+
+        expect(result).to be_an(Array)
+        expect(result.length).to eq(2)
+        expect(result).to include({ id: tag1.id, name: "緊急" })
+        expect(result).to include({ id: tag2.id, name: "重要" })
+      end
+    end
+
+    context "空配列の場合" do
+      it "空配列を返すこと" do
+        result = described_class.render_tags([])
+
+        expect(result).to eq([])
+      end
+    end
+
+    context "nilの場合" do
+      it "空配列を返すこと" do
+        result = described_class.render_tags(nil)
+
+        expect(result).to eq([])
+      end
+
+      it "警告ログを出力すること" do
+        expect(Rails.logger).to receive(:warn).with(/received nil tags/)
+        described_class.render_tags(nil)
+      end
+    end
+  end
+end

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -15,15 +15,10 @@ RSpec.describe Presenters::TagPresenter, type: :model do
     end
 
     context "nilの場合" do
-      it "nilを返すこと" do
-        result = described_class.render_tag(nil)
-
-        expect(result).to be_nil
-      end
-
-      it "警告ログを出力すること" do
-        expect(Rails.logger).to receive(:warn).with(/received nil tag/)
-        described_class.render_tag(nil)
+      it "ArgumentErrorを発生させること" do
+        expect { described_class.render_tag(nil) }.to raise_error(
+          ArgumentError, "TagPresenter.render_tag received nil tag"
+        )
       end
     end
   end
@@ -52,15 +47,10 @@ RSpec.describe Presenters::TagPresenter, type: :model do
     end
 
     context "nilの場合" do
-      it "空配列を返すこと" do
-        result = described_class.render_tags(nil)
-
-        expect(result).to eq([])
-      end
-
-      it "警告ログを出力すること" do
-        expect(Rails.logger).to receive(:warn).with(/received nil tags/)
-        described_class.render_tags(nil)
+      it "ArgumentErrorを発生させること" do
+        expect { described_class.render_tags(nil) }.to raise_error(
+          ArgumentError, "TagPresenter.render_tags received nil tags"
+        )
       end
     end
   end

--- a/spec/requests/api/comments_spec.rb
+++ b/spec/requests/api/comments_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe "Api::Comments", type: :request do
 
   describe "GET /api/comments" do
     before do
-      @admin_comment = create(:comment, account: admin, task: task, content: "管理者コメント")
-      @member_comment = create(:comment, account: member, task: task, content: "メンバーコメント")
-      @other_comment = create(:comment, account: other_member, task: task, content: "他メンバーコメント")
+      @admin_comment = create(:comment, account: admin, task:, content: "管理者コメント")
+      @member_comment = create(:comment, account: member, task:, content: "メンバーコメント")
+      @other_comment = create(:comment, account: other_member, task:, content: "他メンバーコメント")
     end
 
     context "認証なしの場合" do
@@ -83,7 +83,7 @@ RSpec.describe "Api::Comments", type: :request do
   end
 
   describe "GET /api/comments/:id" do
-    let(:member_comment) { create(:comment, account: member, task: task, content: "テストコメント") }
+    let(:member_comment) { create(:comment, account: member, task:, content: "テストコメント") }
 
     context "認証なしの場合" do
       it "Status 401が返ってくること" do
@@ -187,7 +187,7 @@ RSpec.describe "Api::Comments", type: :request do
   end
 
   describe "PUT /api/comments/:id" do
-    let(:member_comment) { create(:comment, account: member, task: task, content: "元のコメント") }
+    let(:member_comment) { create(:comment, account: member, task:, content: "元のコメント") }
 
     context "認証なしの場合" do
       it "Status 401が返ってくること" do
@@ -246,7 +246,7 @@ RSpec.describe "Api::Comments", type: :request do
 
   describe "DELETE /api/comments/:id" do
     context "認証なしの場合" do
-      let!(:comment) { create(:comment, account: member, task: task) }
+      let!(:comment) { create(:comment, account: member, task:) }
 
       it "Status 401が返ってくること" do
         delete "/api/comments/#{comment.id}"
@@ -255,7 +255,7 @@ RSpec.describe "Api::Comments", type: :request do
     end
 
     context "所有者が削除する場合" do
-      let!(:member_comment) { create(:comment, account: member, task: task) }
+      let!(:member_comment) { create(:comment, account: member, task:) }
 
       it "Status 200が返ってくること" do
         delete "/api/comments/#{member_comment.id}", headers: member_headers
@@ -276,7 +276,7 @@ RSpec.describe "Api::Comments", type: :request do
     end
 
     context "adminが削除する場合" do
-      let!(:member_comment) { create(:comment, account: member, task: task) }
+      let!(:member_comment) { create(:comment, account: member, task:) }
 
       it "Status 200が返ってくること" do
         delete "/api/comments/#{member_comment.id}", headers: admin_headers
@@ -285,7 +285,7 @@ RSpec.describe "Api::Comments", type: :request do
     end
 
     context "他のmemberが削除する場合" do
-      let!(:member_comment) { create(:comment, account: member, task: task) }
+      let!(:member_comment) { create(:comment, account: member, task:) }
 
       it "Status 403が返ってくること" do
         delete "/api/comments/#{member_comment.id}", headers: other_member_headers

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -3,67 +3,158 @@
 require "rails_helper"
 
 RSpec.describe "Api::Tags", type: :request do
+  let!(:admin) { create(:account, role: "admin") }
+  let!(:member) { create(:account_member) }
+  let(:admin_token) { JsonWebToken.encode({ account_id: admin.id }) }
+  let(:member_token) { JsonWebToken.encode({ account_id: member.id }) }
+  let(:admin_headers) { { "Authorization" => "Bearer #{admin_token}" } }
+  let(:member_headers) { { "Authorization" => "Bearer #{member_token}" } }
+
   describe "GET /api/tags" do
     before do
       @tag1 = create(:tag, name: "重要")
       @tag2 = create(:tag, name: "緊急")
     end
 
-    it "Status 200が返ってくること" do
-      get "/api/tags"
-      expect(response).to have_http_status(:ok)
+    context "認証済みユーザーの場合" do
+      it "Status 200が返ってくること" do
+        get "/api/tags", headers: admin_headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "全てのタグが返ってくること" do
+        get "/api/tags", headers: admin_headers
+        json_response = JSON.parse(response.body)
+        expect(json_response.length).to eq(2)
+      end
+
+      it "正しい形式のデータが返ってくること" do
+        get "/api/tags", headers: admin_headers
+        json_response = JSON.parse(response.body)
+        expect(json_response[0]).to have_key("id")
+        expect(json_response[0]).to have_key("name")
+      end
+
+      it "memberユーザーでも取得できること" do
+        get "/api/tags", headers: member_headers
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it "全てのタグが返ってくること" do
-      get "/api/tags"
-      json_response = JSON.parse(response.body)
-      expect(json_response.length).to eq(2)
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        get "/api/tags"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe "GET /api/tags/:id" do
+    before do
+      @tag = create(:tag, name: "緊急")
     end
 
-    it "正しい形式のデータが返ってくること" do
-      get "/api/tags"
-      json_response = JSON.parse(response.body)
-      expect(json_response[0]).to have_key("id")
-      expect(json_response[0]).to have_key("name")
+    context "認証済みユーザーの場合" do
+      context "存在するタグの場合" do
+        it "Status 200が返ってくること" do
+          get "/api/tags/#{@tag.id}", headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "正しいデータが返ってくること" do
+          get "/api/tags/#{@tag.id}", headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["id"]).to eq(@tag.id)
+          expect(json_response["name"]).to eq("緊急")
+        end
+
+        it "memberユーザーでも取得できること" do
+          get "/api/tags/#{@tag.id}", headers: member_headers
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "存在しないタグの場合" do
+        it "Status 404が返ってくること" do
+          get "/api/tags/999999", headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "無効なIDフォーマットの場合" do
+        it "文字列IDでStatus 422が返ってくること" do
+          get "/api/tags/abc", headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        get "/api/tags/#{@tag.id}"
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 
   describe "POST /api/tags" do
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        post "/api/tags", params: { tag: { name: "新規タグ" } }
-        expect(response).to have_http_status(:ok)
+    context "adminユーザーの場合" do
+      context "有効なパラメータの場合" do
+        it "Status 201が返ってくること" do
+          post "/api/tags", params: { tag: { name: "新規タグ" } }, headers: admin_headers
+          expect(response).to have_http_status(:created)
+        end
+
+        it "タグが作成されること" do
+          expect {
+            post "/api/tags", params: { tag: { name: "新規タグ" } }, headers: admin_headers
+          }.to change(Tag, :count).by(1)
+        end
+
+        it "作成されたデータが返ってくること" do
+          post "/api/tags", params: { tag: { name: "新規タグ" } }, headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["name"]).to eq("新規タグ")
+        end
       end
 
-      it "タグが作成されること" do
-        expect {
-          post "/api/tags", params: { tag: { name: "新規タグ" } }
-        }.to change(Tag, :count).by(1)
-      end
+      context "無効なパラメータの場合" do
+        it "nameが空の場合、Status 422が返ってくること" do
+          post "/api/tags", params: { tag: { name: "" } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
 
-      it "作成されたデータが返ってくること" do
-        post "/api/tags", params: { tag: { name: "新規タグ" } }
-        json_response = JSON.parse(response.body)
-        expect(json_response["name"]).to eq("新規タグ")
+        it "nameが32文字を超える場合、Status 422が返ってくること" do
+          post "/api/tags", params: { tag: { name: "a" * 33 } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/tags", params: { tag: { name: "" } }, headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response).to have_key("errors")
+          expect(json_response["status"]).to eq(422)
+        end
       end
     end
 
-    context "無効なパラメータの場合" do
-      it "nameが空の場合、Status 422が返ってくること" do
-        post "/api/tags", params: { tag: { name: "" } }
-        expect(response).to have_http_status(:unprocessable_entity)
+    context "memberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        post "/api/tags", params: { tag: { name: "新規タグ" } }, headers: member_headers
+        expect(response).to have_http_status(:forbidden)
       end
 
-      it "nameが32文字を超える場合、Status 422が返ってくること" do
-        post "/api/tags", params: { tag: { name: "a" * 33 } }
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "タグが作成されないこと" do
+        expect {
+          post "/api/tags", params: { tag: { name: "新規タグ" } }, headers: member_headers
+        }.not_to change(Tag, :count)
       end
+    end
 
-      it "エラーメッセージが返ってくること" do
-        post "/api/tags", params: { tag: { name: "" } }
-        json_response = JSON.parse(response.body)
-        expect(json_response).to have_key("message")
-        expect(json_response["status"]).to eq(422)
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        post "/api/tags", params: { tag: { name: "新規タグ" } }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -73,29 +164,65 @@ RSpec.describe "Api::Tags", type: :request do
       @tag = create(:tag, name: "元の名前")
     end
 
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }
-        expect(response).to have_http_status(:ok)
+    context "adminユーザーの場合" do
+      context "有効なパラメータの場合" do
+        it "Status 200が返ってくること" do
+          put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }, headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "更新されたデータが返ってくること" do
+          put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }, headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["name"]).to eq("更新後の名前")
+        end
+
+        it "DBが更新されていること" do
+          put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }, headers: admin_headers
+          @tag.reload
+          expect(@tag.name).to eq("更新後の名前")
+        end
       end
 
-      it "更新されたデータが返ってくること" do
-        put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }
-        json_response = JSON.parse(response.body)
-        expect(json_response["name"]).to eq("更新後の名前")
+      context "存在しないタグの場合" do
+        it "Status 404が返ってくること" do
+          put "/api/tags/999999", params: { tag: { name: "更新" } }, headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
       end
 
-      it "DBが更新されていること" do
-        put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }
-        @tag.reload
-        expect(@tag.name).to eq("更新後の名前")
+      context "無効なIDフォーマットの場合" do
+        it "文字列IDでStatus 422が返ってくること" do
+          put "/api/tags/abc", params: { tag: { name: "更新" } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "無効なパラメータの場合" do
+        it "nameが32文字を超える場合、Status 422が返ってくること" do
+          put "/api/tags/#{@tag.id}", params: { tag: { name: "a" * 33 } }, headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
       end
     end
 
-    context "存在しないタグの場合" do
-      it "Status 404が返ってくること" do
-        put "/api/tags/999999", params: { tag: { name: "更新" } }
-        expect(response).to have_http_status(:not_found)
+    context "memberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }, headers: member_headers
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "DBが更新されないこと" do
+        put "/api/tags/#{@tag.id}", params: { tag: { name: "更新後の名前" } }, headers: member_headers
+        @tag.reload
+        expect(@tag.name).to eq("元の名前")
+      end
+    end
+
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        put "/api/tags/#{@tag.id}", params: { tag: { name: "更新" } }
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
@@ -105,23 +232,75 @@ RSpec.describe "Api::Tags", type: :request do
       @tag = create(:tag, name: "削除対象")
     end
 
-    context "存在するタグの場合" do
-      it "Status 204が返ってくること" do
-        delete "/api/tags/#{@tag.id}"
-        expect(response).to have_http_status(:no_content)
+    context "adminユーザーの場合" do
+      context "存在するタグの場合" do
+        it "Status 200が返ってくること" do
+          delete "/api/tags/#{@tag.id}", headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "タグが削除されること" do
+          expect {
+            delete "/api/tags/#{@tag.id}", headers: admin_headers
+          }.to change(Tag, :count).by(-1)
+        end
+
+        it "削除メッセージが返ってくること" do
+          delete "/api/tags/#{@tag.id}", headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["message"]).to eq("deleted")
+        end
       end
 
-      it "タグが削除されること" do
-        expect {
-          delete "/api/tags/#{@tag.id}"
-        }.to change(Tag, :count).by(-1)
+      context "存在しないタグの場合" do
+        it "Status 404が返ってくること" do
+          delete "/api/tags/999999", headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "無効なIDフォーマットの場合" do
+        it "文字列IDでStatus 422が返ってくること" do
+          delete "/api/tags/abc", headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "FK制約違反の場合" do
+        before do
+          admin.tags << @tag
+        end
+
+        it "Status 409が返ってくること" do
+          delete "/api/tags/#{@tag.id}", headers: admin_headers
+          expect(response).to have_http_status(:conflict)
+        end
+
+        it "タグが削除されないこと" do
+          expect {
+            delete "/api/tags/#{@tag.id}", headers: admin_headers
+          }.not_to change(Tag, :count)
+        end
       end
     end
 
-    context "存在しないタグの場合" do
-      it "Status 404が返ってくること" do
-        delete "/api/tags/999999"
-        expect(response).to have_http_status(:not_found)
+    context "memberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        delete "/api/tags/#{@tag.id}", headers: member_headers
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "タグが削除されないこと" do
+        expect {
+          delete "/api/tags/#{@tag.id}", headers: member_headers
+        }.not_to change(Tag, :count)
+      end
+    end
+
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        delete "/api/tags/#{@tag.id}"
+        expect(response).to have_http_status(:unauthorized)
       end
     end
   end

--- a/spec/services/tags/create_spec.rb
+++ b/spec/services/tags/create_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tags::Create, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+
+    let(:valid_params) { { name: "緊急" } }
+
+    describe "正常系" do
+      context "adminユーザーが有効なパラメータでタグを作成する場合" do
+        it "成功してタグを作成すること" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.to change(Tag, :count).by(1)
+        end
+
+        it "作成されたタグ情報を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:created)
+          expect(result.tag.name).to eq("緊急")
+          expect(result.errors).to be_empty
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(valid_params, admin)
+          rendered = Presenters::TagPresenter.render_tag(result.tag)
+
+          expect(rendered).to have_key(:id)
+          expect(rendered[:name]).to eq("緊急")
+        end
+      end
+
+      context "params[:tag][:name]形式の場合" do
+        it "成功すること" do
+          result = described_class.new.call({ tag: { name: "重要" } }, admin)
+
+          expect(result.success?).to be true
+          expect(result.tag.name).to eq("重要")
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "バリデーションエラーの場合" do
+        it "nameが空の場合、失敗を返すこと" do
+          result = described_class.new.call({ name: "" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+          expect(result.errors).not_to be_empty
+        end
+
+        it "nameが33文字の場合、失敗を返すこと" do
+          result = described_class.new.call({ name: "a" * 33 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "タグが作成されないこと" do
+          expect {
+            described_class.new.call({ name: "" }, admin)
+          }.not_to change(Tag, :count)
+        end
+      end
+
+      describe "権限エラーの場合" do
+        let(:current_account) { member }
+        let(:result) { described_class.new.call(valid_params, current_account) }
+
+        it_behaves_like "admin only service"
+
+        it "タグが作成されないこと" do
+          expect {
+            described_class.new.call(valid_params, member)
+          }.not_to change(Tag, :count)
+        end
+      end
+
+      context "一意性制約違反の場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:build).and_return(Tag.new(name: "緊急"))
+          allow(mock_repository).to receive(:save).and_raise(ActiveRecord::RecordNotUnique.new("Duplicate entry"))
+        end
+
+        it "conflictを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:conflict)
+          expect(result.errors).to include("このタグは既に存在します")
+        end
+      end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:build).and_return(Tag.new(name: "緊急"))
+          allow(mock_repository).to receive(:save).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tags/destroy_spec.rb
+++ b/spec/services/tags/destroy_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tags::Destroy, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:tag) { create(:tag, name: "緊急") }
+
+    let(:valid_params) { { id: tag.id } }
+
+    describe "正常系" do
+      context "adminユーザーが削除する場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.message).to eq("deleted")
+          expect(result.errors).to be_empty
+        end
+
+        it "タグが削除されること" do
+          expect {
+            described_class.new.call(valid_params, admin)
+          }.to change(Tag, :count).by(-1)
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect({ message: result.message }).to eq({ message: "deleted" })
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "バリデーションエラーの場合" do
+        it "idが無効な場合、失敗を返すこと" do
+          result = described_class.new.call({ id: "abc" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "タグが削除されないこと" do
+          expect {
+            described_class.new.call({ id: "abc" }, admin)
+          }.not_to change(Tag, :count)
+        end
+      end
+
+      describe "権限エラーの場合" do
+        let(:current_account) { member }
+        let(:result) { described_class.new.call(valid_params, current_account) }
+
+        it_behaves_like "admin only service"
+
+        it "タグが削除されないこと" do
+          expect {
+            described_class.new.call(valid_params, member)
+          }.not_to change(Tag, :count)
+        end
+      end
+
+      context "タグが存在しない場合" do
+        it "not_foundを返すこと" do
+          result = described_class.new.call({ id: 999999 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors.first).to include("999999")
+        end
+      end
+
+      context "FK制約違反の場合" do
+        let!(:tag_with_account) { create(:tag, name: "重要") }
+
+        before do
+          # タグにアカウントを紐付ける
+          admin.tags << tag_with_account
+        end
+
+        it "conflictを返すこと" do
+          result = described_class.new.call({ id: tag_with_account.id }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:conflict)
+          expect(result.errors.first).to include("アカウントが関連付けられている")
+        end
+
+        it "タグが削除されないこと" do
+          expect {
+            described_class.new.call({ id: tag_with_account.id }, admin)
+          }.not_to change(Tag, :count)
+        end
+      end
+
+      context "ロックタイムアウトが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::LockWaitTimeout)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+          expect(result.errors.first).to include("混雑")
+        end
+      end
+
+      context "デッドロックが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::Deadlocked)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+          expect(result.errors.first).to include("混雑")
+        end
+      end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tags/destroy_spec.rb
+++ b/spec/services/tags/destroy_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Services::Tags::Destroy, type: :service do
 
           expect(result.success?).to be false
           expect(result.status).to eq(:conflict)
-          expect(result.errors.first).to include("アカウントが関連付けられている")
+          expect(result.errors.first).to include("アカウントまたはタスクが関連付けられている")
         end
 
         it "タグが削除されないこと" do

--- a/spec/services/tags/index_spec.rb
+++ b/spec/services/tags/index_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tags::Index, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:tag1) { create(:tag, name: "緊急") }
+    let!(:tag2) { create(:tag, name: "重要") }
+
+    describe "正常系" do
+      context "adminユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "全タグを返すこと" do
+          result = described_class.new.call(admin)
+
+          expect(result.tags.length).to eq(2)
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(admin)
+          rendered = Presenters::TagPresenter.render_tags(result.tags)
+
+          expect(rendered).to be_an(Array)
+          expect(rendered.first).to have_key(:id)
+          expect(rendered.first).to have_key(:name)
+        end
+      end
+
+      context "memberユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(member)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "current_accountがnilの場合" do
+        it "unauthorizedを返すこと" do
+          result = described_class.new.call(nil)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unauthorized)
+          expect(result.errors).to include("認証が必要です")
+        end
+      end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:all_tags).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tags/show_spec.rb
+++ b/spec/services/tags/show_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tags::Show, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:tag) { create(:tag, name: "緊急") }
+
+    describe "正常系" do
+      context "adminユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call({ id: tag.id }, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "指定したタグを返すこと" do
+          result = described_class.new.call({ id: tag.id }, admin)
+
+          expect(result.tag.id).to eq(tag.id)
+          expect(result.tag.name).to eq("緊急")
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call({ id: tag.id }, admin)
+          rendered = Presenters::TagPresenter.render_tag(result.tag)
+
+          expect(rendered).to eq({ id: tag.id, name: "緊急" })
+        end
+      end
+
+      context "memberユーザーの場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call({ id: tag.id }, member)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "current_accountがnilの場合" do
+        it "unauthorizedを返すこと" do
+          result = described_class.new.call({ id: tag.id }, nil)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unauthorized)
+          expect(result.errors).to include("認証が必要です")
+        end
+      end
+
+      context "バリデーションエラーの場合" do
+        it "idが無効な場合、unprocessable_entityを返すこと" do
+          result = described_class.new.call({ id: "abc" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+      end
+
+      context "タグが存在しない場合" do
+        it "not_foundを返すこと" do
+          result = described_class.new.call({ id: 999999 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors.first).to include("999999")
+        end
+      end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call({ id: 1 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tags/update_spec.rb
+++ b/spec/services/tags/update_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Tags::Update, type: :service do
+  describe "#call" do
+    let!(:admin) { create(:account, role: "admin") }
+    let!(:member) { create(:account_member) }
+    let!(:tag) { create(:tag, name: "緊急") }
+
+    let(:valid_params) { { id: tag.id, name: "重要" } }
+
+    describe "正常系" do
+      context "adminユーザーが有効なパラメータでタグを更新する場合" do
+        it "成功を返すこと" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.success?).to be true
+          expect(result.status).to eq(:ok)
+          expect(result.errors).to be_empty
+        end
+
+        it "タグ名が更新されること" do
+          result = described_class.new.call(valid_params, admin)
+
+          expect(result.tag.name).to eq("重要")
+        end
+
+        it "DBが更新されること" do
+          described_class.new.call(valid_params, admin)
+
+          tag.reload
+          expect(tag.name).to eq("重要")
+        end
+
+        it "Presenterでレンダリングできること" do
+          result = described_class.new.call(valid_params, admin)
+          rendered = Presenters::TagPresenter.render_tag(result.tag)
+
+          expect(rendered[:id]).to eq(tag.id)
+          expect(rendered[:name]).to eq("重要")
+        end
+      end
+
+      context "params[:tag][:name]形式の場合" do
+        it "成功すること" do
+          result = described_class.new.call({ id: tag.id, tag: { name: "高優先" } }, admin)
+
+          expect(result.success?).to be true
+          expect(result.tag.name).to eq("高優先")
+        end
+      end
+
+      context "nameがnilの場合" do
+        it "更新されないこと" do
+          original_name = tag.name
+          result = described_class.new.call({ id: tag.id, name: nil }, admin)
+
+          expect(result.success?).to be true
+          tag.reload
+          expect(tag.name).to eq(original_name)
+        end
+      end
+    end
+
+    describe "異常系" do
+      context "バリデーションエラーの場合" do
+        it "idが無効な場合、失敗を返すこと" do
+          result = described_class.new.call({ id: "abc", name: "重要" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "nameが33文字の場合、失敗を返すこと" do
+          result = described_class.new.call({ id: tag.id, name: "a" * 33 }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:unprocessable_entity)
+        end
+
+        it "DBが更新されないこと" do
+          original_name = tag.name
+          described_class.new.call({ id: tag.id, name: "a" * 33 }, admin)
+
+          tag.reload
+          expect(tag.name).to eq(original_name)
+        end
+      end
+
+      describe "権限エラーの場合" do
+        let(:current_account) { member }
+        let(:result) { described_class.new.call(valid_params, current_account) }
+
+        it_behaves_like "admin only service"
+
+        it "DBが更新されないこと" do
+          original_name = tag.name
+          described_class.new.call(valid_params, member)
+
+          tag.reload
+          expect(tag.name).to eq(original_name)
+        end
+      end
+
+      context "タグが存在しない場合" do
+        it "not_foundを返すこと" do
+          result = described_class.new.call({ id: 999999, name: "重要" }, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:not_found)
+          expect(result.errors.first).to include("999999")
+        end
+      end
+
+      context "ロックタイムアウトが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::LockWaitTimeout)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+          expect(result.errors.first).to include("混雑")
+        end
+      end
+
+      context "デッドロックが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::Deadlocked)
+        end
+
+        it "service_unavailableを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:service_unavailable)
+        end
+      end
+
+      context "一意性制約違反の場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::RecordNotUnique.new("Duplicate entry"))
+        end
+
+        it "conflictを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:conflict)
+          expect(result.errors).to include("このタグは既に存在します")
+        end
+      end
+
+      context "データベースエラーが発生した場合" do
+        let(:mock_repository) { instance_double(Services::Tags::Repository) }
+
+        before do
+          allow(mock_repository).to receive(:find_by_id_with_lock).and_raise(ActiveRecord::StatementInvalid.new("Database error"))
+        end
+
+        it "internal_server_errorを返すこと" do
+          result = described_class.new(repository: mock_repository).call(valid_params, admin)
+
+          expect(result.success?).to be false
+          expect(result.status).to eq(:internal_server_error)
+          expect(result.errors).to include("データベースエラーが発生しました")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Tags コントローラー（5エンドポイント）を4層アーキテクチャに移行
- **認証必須化**: 全エンドポイントで認証が必要に
- **認可追加**: create/update/destroy は admin のみ許可
- **show追加**: ルート定義済みだが未実装だったエンドポイントを追加

## 変更ファイル一覧

### 新規作成（22ファイル）

**Contracts（5ファイル）**
- `app/contracts/tags/id_contract.rb` - ID検証基底クラス
- `app/contracts/tags/show.rb` - IdContract継承
- `app/contracts/tags/destroy.rb` - IdContract継承
- `app/contracts/tags/create.rb` - name検証
- `app/contracts/tags/update.rb` - id + name検証

**Services（7ファイル）**
- `app/services/tags/repository.rb` - DBアクセス + ログ
- `app/services/tags/result.rb` - 結果オブジェクト
- `app/services/tags/index.rb` - 一覧取得
- `app/services/tags/show.rb` - 詳細取得
- `app/services/tags/create.rb` - 作成 + admin認可
- `app/services/tags/update.rb` - 更新 + admin認可 + 悲観ロック
- `app/services/tags/destroy.rb` - 削除 + admin認可 + 悲観ロック + FK処理

**Policy・Presenter（2ファイル）**
- `app/policies/tag_policy.rb` - admin_only? + nilチェックログ
- `app/presenters/tag_presenter.rb` - nil警告ログパターン

**テスト（10ファイル）**
- `spec/contracts/tags/{id_contract,create,update}_spec.rb`
- `spec/services/tags/{index,show,create,update,destroy}_spec.rb`
- `spec/policies/tag_policy_spec.rb`
- `spec/presenters/tag_presenter_spec.rb`

### 修正（4ファイル）
- `app/controllers/api/tags_controller.rb` - 4層パターン適用
- `spec/requests/api/tags_spec.rb` - 新仕様に対応
- `spec/policies/comment_policy_spec.rb` - RuboCop修正
- `spec/presenters/comment_presenter_spec.rb` - RuboCop修正
- `spec/requests/api/comments_spec.rb` - RuboCop修正

## 破壊的変更

| 変更内容 | Before | After |
|----------|--------|-------|
| 認証 | なし | 全エンドポイント必須（401） |
| create/update/delete認可 | なし | admin限定（403） |
| POST成功ステータス | 200 | 201 |
| DELETE成功ステータス | 204（空） | 200 + `{"message":"deleted"}` |
| GET /api/tags/:id | 未実装 | 新規追加 |
| FK制約エラー | 500 | 409 + エラーメッセージ |

## 例外ハンドリング

| 例外 | ステータス | メッセージ |
|------|-----------|-----------|
| Deadlocked | 503 | サーバーが混雑しています |
| LockWaitTimeout | 503 | サーバーが混雑しています |
| RecordNotUnique | 409 | このタグは既に存在します |
| InvalidForeignKey | 409 | アカウントが関連付けられているため削除できません |
| StatementInvalid | 500 | データベースエラーが発生しました |

## Test plan

- [x] RuboCop pass（252ファイル、オフェンスなし）
- [x] RSpec pass（1449件）
- [x] Tags関連テスト pass（91件 + 39件 = 130件）