### PR TITLE
refactor: Assigns コントローラーを4層アーキテクチャに移行

### DIFF
--- a/app/contracts/assigns/cycle_create.rb
+++ b/app/contracts/assigns/cycle_create.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Contracts
+  module Assigns
+    # サイクル作成の入力検証
+    # params: { assign_cycle: { task_id: Integer } } または { task_id: Integer }
+    class CycleCreate
+      include ActiveModel::Model
+
+      attr_accessor :task_id
+
+      validates :task_id, presence: { message: "タスクIDは必須です" }
+      validates :task_id, numericality: { only_integer: true, greater_than: 0, message: "タスクIDは正の整数である必要があります" }, if: -> { task_id.present? }
+
+      def self.call(params)
+        # assign_cycle ネストに対応
+        raw_task_id = params.dig(:assign_cycle, :task_id) || params[:task_id]
+        contract = new(task_id: raw_task_id)
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { task_id: task_id.to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/api/assigns_controller.rb
+++ b/app/controllers/api/assigns_controller.rb
@@ -1,21 +1,17 @@
 # frozen_string_literal: true
 
 class Api::AssignsController < ApplicationController
-  # TODO: indexメソッドの実装が必要な場合は追加してください
-  # 現在はcycle_createのみが使用されています
+  before_action :authenticated?
 
+  # POST /api/tasks/assign/cycle
+  # サイクルを作成し、自動割り当てを実行
   def cycle_create
-    cycle = AssignCycle.new(cycle_params)
-
-    if cycle.save
-      render json: cycle
-    else
-      render json: { message: cycle.errors, status: 422 }, status: :unprocessable_entity
-    end
+    result = ::Services::Assigns::CycleCreate.new.call(cycle_create_params, @current_account)
+    render_result(result) { ::Presenters::AssignCyclePresenter.render_cycle(result.cycle) }
   end
 
   private
-    def cycle_params
-      params.require(:assign_cycle).permit(:task_id)
+    def cycle_create_params
+      { assign_cycle: params.require(:assign_cycle).permit(:task_id) }
     end
 end

--- a/app/controllers/api/assigns_controller.rb
+++ b/app/controllers/api/assigns_controller.rb
@@ -7,7 +7,13 @@ class Api::AssignsController < ApplicationController
   # サイクルを作成し、自動割り当てを実行
   def cycle_create
     result = ::Services::Assigns::CycleCreate.new.call(cycle_create_params, @current_account)
-    render_result(result) { ::Presenters::AssignCyclePresenter.render_cycle(result.cycle) }
+    render_result(result) do
+      if result.cycle.nil?
+        Rails.logger.error "CycleCreate returned success but cycle is nil"
+        raise ArgumentError, "Unexpected nil cycle on success"
+      end
+      ::Presenters::AssignCyclePresenter.render_cycle(result.cycle)
+    end
   end
 
   private

--- a/app/models/assign_cycle.rb
+++ b/app/models/assign_cycle.rb
@@ -6,6 +6,10 @@ class AssignCycle < ApplicationRecord
   has_many :assign_histories
   has_many :comments
 
+  # 割り当て可能なアカウントに割り当てを実行
+  # @return [AssignHistory] 割り当て成功時
+  # @return [false] 割り当て可能なアカウントがない場合
+  # @raise [ActiveRecord::RecordInvalid] AssignHistory の保存に失敗した場合
   def assign
     accounts = ::Services::AssignableAccountsService.new(assign_cycle: self).call
     target = accounts.first
@@ -13,7 +17,8 @@ class AssignCycle < ApplicationRecord
     return false if target.nil?
 
     current_assign = AssignHistory.new(account_id: target.id, assign_cycle_id: id)
-    current_assign.save ? current_assign : false
+    current_assign.save!
+    current_assign
   end
 
   def get_assignable

--- a/app/presenters/assign_cycle_presenter.rb
+++ b/app/presenters/assign_cycle_presenter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Presenters
+  # サイクルのレスポンス整形を担当
+  class AssignCyclePresenter
+    class << self
+      # 単一サイクルをレスポンス形式に変換
+      # @param cycle [AssignCycle] サイクルオブジェクト
+      # @return [Hash]
+      # @raise [ArgumentError] cycle が nil の場合
+      def render_cycle(cycle)
+        raise ArgumentError, "AssignCyclePresenter.render_cycle received nil cycle" if cycle.nil?
+
+        {
+          id: cycle.id,
+          task_id: cycle.task_id,
+          is_active: cycle.is_active,
+          created_at: cycle.created_at,
+          updated_at: cycle.updated_at
+        }
+      end
+    end
+  end
+end

--- a/app/services/assigns/cycle_create.rb
+++ b/app/services/assigns/cycle_create.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Services
+  module Assigns
+    # サイクル作成サービス
+    #
+    # 認可: admin のみ
+    # 同時更新防止: 悲観ロック
+    class CycleCreate
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { assign_cycle: { task_id: Integer } } または { task_id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # 認可チェック（admin_only）
+        policy = ::Policies::AccountPolicy.new(current_account)
+        unless policy.admin_only?
+          Rails.logger.warn "Cycle create unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
+
+        # Contract検証
+        validation = ::Contracts::Assigns::CycleCreate.call(params)
+        unless validation.success?
+          Rails.logger.warn "Cycle create validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        task_id = validation.value[:task_id]
+
+        # トランザクション内で処理
+        result = nil
+        Task.transaction do
+          # Task取得（悲観的ロック）
+          task = @repository.find_task_with_lock(task_id)
+          if task.nil?
+            Rails.logger.warn "Task not found for cycle create: task_id=#{task_id}, by_account=#{current_account.id}"
+            result = failure(["タスクが見つかりません"], :not_found)
+            raise ActiveRecord::Rollback
+          end
+
+          # 既存サイクルを非アクティブ化
+          deactivated_count = @repository.deactivate_all_cycles(task)
+          Rails.logger.debug "Deactivated #{deactivated_count} cycles for task_id=#{task.id}"
+
+          # 新サイクル作成
+          cycle = @repository.create_cycle(task)
+
+          # 割り当て実行
+          assign_result = cycle.assign
+
+          if assign_result
+            Rails.logger.info "Cycle created: task_id=#{task.id}, cycle_id=#{cycle.id}, by_account=#{current_account.id}, assignee_id=#{assign_result.account_id}"
+            result = success(cycle)
+          else
+            Rails.logger.warn "Cycle created but assignment failed: task_id=#{task.id}, cycle_id=#{cycle.id}, no_eligible_accounts=true"
+            result = failure(["割り当て可能なメンバーがいません"], :unprocessable_entity)
+            raise ActiveRecord::Rollback
+          end
+        end
+        result
+      rescue ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout => e
+        Rails.logger.error "Cycle create lock error: task_id=#{params.dig(:assign_cycle, :task_id) || params[:task_id]}, error=#{e.message}"
+        failure(["サーバーが混雑しています。しばらくしてから再度お試しください"], :service_unavailable)
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error "Cycle create save error: task_id=#{params.dig(:assign_cycle, :task_id) || params[:task_id]}, error=#{e.message}"
+        failure(["サイクル作成に失敗しました"], :unprocessable_entity)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Cycle create DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def success(cycle)
+          Result.new(success?: true, cycle:, message: nil, errors: [], status: :created)
+        end
+
+        def failure(errors, status)
+          Result.new(success?: false, cycle: nil, message: "failed", errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/assigns/cycle_create.rb
+++ b/app/services/assigns/cycle_create.rb
@@ -69,8 +69,8 @@ module Services
         Rails.logger.error "Cycle create lock error: task_id=#{params.dig(:assign_cycle, :task_id) || params[:task_id]}, error=#{e.message}"
         failure(["サーバーが混雑しています。しばらくしてから再度お試しください"], :service_unavailable)
       rescue ActiveRecord::RecordInvalid => e
-        Rails.logger.error "Cycle create save error: task_id=#{params.dig(:assign_cycle, :task_id) || params[:task_id]}, error=#{e.message}"
-        failure(["サイクル作成に失敗しました"], :unprocessable_entity)
+        Rails.logger.error "Cycle create/assign save error: task_id=#{params.dig(:assign_cycle, :task_id) || params[:task_id]}, error=#{e.message}"
+        failure(["サイクル作成または割り当てに失敗しました: #{e.record.errors.full_messages.join(', ')}"], :unprocessable_entity)
       rescue ActiveRecord::StatementInvalid => e
         Rails.logger.error "Cycle create DB error: #{e.message}"
         failure(["データベースエラーが発生しました"], :internal_server_error)

--- a/app/services/assigns/repository.rb
+++ b/app/services/assigns/repository.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Services
+  module Assigns
+    # サイクル作成用のリポジトリ
+    class Repository
+      # タスクをIDで取得（悲観的ロック付き）
+      # @param task_id [Integer] タスクID
+      # @return [Task, nil]
+      def find_task_with_lock(task_id)
+        Task.lock.find_by(id: task_id)
+      end
+
+      # タスクの全サイクルを非アクティブ化
+      # @param task [Task]
+      # @return [Integer] 更新された行数
+      def deactivate_all_cycles(task)
+        AssignCycle.where(task_id: task.id).update_all(is_active: false)
+      end
+
+      # 新しいサイクルを作成
+      # @param task [Task]
+      # @return [AssignCycle]
+      # @raise [ActiveRecord::RecordInvalid] バリデーション失敗時
+      def create_cycle(task)
+        task.assign_cycles.create!
+      end
+    end
+  end
+end

--- a/app/services/assigns/result.rb
+++ b/app/services/assigns/result.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Services
+  module Assigns
+    # サイクル操作の結果を表すStruct
+    # @!attribute success?
+    #   @return [Boolean] 操作が成功したかどうか
+    # @!attribute cycle
+    #   @return [AssignCycle, nil] 作成されたサイクル
+    # @!attribute message
+    #   @return [String, nil] 結果メッセージ
+    # @!attribute errors
+    #   @return [Array<String>] エラーメッセージ配列
+    # @!attribute status
+    #   @return [Symbol] HTTPステータスシンボル
+    Result = Struct.new(:success?, :cycle, :message, :errors, :status, keyword_init: true)
+  end
+end

--- a/spec/contracts/assigns/cycle_create_spec.rb
+++ b/spec/contracts/assigns/cycle_create_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::Assigns::CycleCreate do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      context "assign_cycleネストありの場合" do
+        let(:params) { { assign_cycle: { task_id: "1" } } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "valueにnormalized_attributesを返すこと" do
+          result = described_class.call(params)
+          expect(result.value).to eq({ task_id: 1 })
+        end
+
+        it "errorsが空であること" do
+          result = described_class.call(params)
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context "assign_cycleネストなしの場合" do
+        let(:params) { { task_id: "123" } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "task_idが整数に変換されること" do
+          result = described_class.call(params)
+          expect(result.value[:task_id]).to eq(123)
+        end
+      end
+
+      context "task_idが整数の場合" do
+        let(:params) { { assign_cycle: { task_id: 456 } } }
+
+        it "success?がtrueを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be true
+        end
+
+        it "task_idがそのまま整数として返されること" do
+          result = described_class.call(params)
+          expect(result.value[:task_id]).to eq(456)
+        end
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "task_idが空文字列の場合" do
+        let(:params) { { assign_cycle: { task_id: "" } } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("タスクIDは必須です")
+        end
+      end
+
+      context "task_idがnilの場合" do
+        let(:params) { { assign_cycle: { task_id: nil } } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("タスクIDは必須です")
+        end
+      end
+
+      context "パラメータが空の場合" do
+        let(:params) { {} }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("タスクIDは必須です")
+        end
+      end
+
+      context "task_idが非数値の場合" do
+        let(:params) { { assign_cycle: { task_id: "abc" } } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("タスクIDは正の整数である必要があります")
+        end
+      end
+
+      context "task_idが0の場合" do
+        let(:params) { { assign_cycle: { task_id: "0" } } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("タスクIDは正の整数である必要があります")
+        end
+      end
+
+      context "task_idが負数の場合" do
+        let(:params) { { assign_cycle: { task_id: "-1" } } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("タスクIDは正の整数である必要があります")
+        end
+      end
+
+      context "task_idが小数の場合" do
+        let(:params) { { assign_cycle: { task_id: "1.5" } } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("タスクIDは正の整数である必要があります")
+        end
+      end
+    end
+  end
+
+  describe "#normalized_attributes" do
+    context "文字列のtask_idの場合" do
+      it "task_idが整数に変換されること" do
+        contract = described_class.new(task_id: "42")
+        expect(contract.normalized_attributes).to eq({ task_id: 42 })
+      end
+    end
+
+    context "整数のtask_idの場合" do
+      it "task_idがそのまま返されること" do
+        contract = described_class.new(task_id: 100)
+        expect(contract.normalized_attributes).to eq({ task_id: 100 })
+      end
+    end
+  end
+end

--- a/spec/presenters/assign_cycle_presenter_spec.rb
+++ b/spec/presenters/assign_cycle_presenter_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Presenters::AssignCyclePresenter do
+  describe ".render_cycle" do
+    context "有効なサイクルの場合" do
+      let!(:area) { create(:area) }
+      let!(:task) { create(:task, area:) }
+      let!(:cycle) { create(:assign_cycle, task:, is_active: true) }
+
+      it "正しいハッシュを返すこと" do
+        result = described_class.render_cycle(cycle)
+        expect(result).to eq({
+          id: cycle.id,
+          task_id: cycle.task_id,
+          is_active: true,
+          created_at: cycle.created_at,
+          updated_at: cycle.updated_at
+        })
+      end
+
+      it "idを含むこと" do
+        result = described_class.render_cycle(cycle)
+        expect(result[:id]).to eq(cycle.id)
+      end
+
+      it "task_idを含むこと" do
+        result = described_class.render_cycle(cycle)
+        expect(result[:task_id]).to eq(task.id)
+      end
+
+      it "is_activeを含むこと" do
+        result = described_class.render_cycle(cycle)
+        expect(result[:is_active]).to be true
+      end
+
+      it "created_atを含むこと" do
+        result = described_class.render_cycle(cycle)
+        expect(result[:created_at]).to eq(cycle.created_at)
+      end
+
+      it "updated_atを含むこと" do
+        result = described_class.render_cycle(cycle)
+        expect(result[:updated_at]).to eq(cycle.updated_at)
+      end
+    end
+
+    context "is_activeがfalseのサイクルの場合" do
+      let!(:area) { create(:area) }
+      let!(:task) { create(:task, area:) }
+      let!(:cycle) { create(:assign_cycle, task:, is_active: false) }
+
+      it "is_activeがfalseであること" do
+        result = described_class.render_cycle(cycle)
+        expect(result[:is_active]).to be false
+      end
+    end
+
+    context "cycleがnilの場合" do
+      it "ArgumentErrorを発生させること" do
+        expect {
+          described_class.render_cycle(nil)
+        }.to raise_error(ArgumentError, "AssignCyclePresenter.render_cycle received nil cycle")
+      end
+    end
+  end
+end

--- a/spec/requests/api/assigns_spec.rb
+++ b/spec/requests/api/assigns_spec.rb
@@ -2,50 +2,173 @@
 
 require "rails_helper"
 
-RSpec.describe Api::AssignsController, type: :controller do
-  describe "POST #cycle_create" do
+RSpec.describe "Api::Assigns", type: :request do
+  let!(:admin) { create(:account, role: "admin") }
+  let!(:member) { create(:account_member) }
+  let(:admin_token) { JsonWebToken.encode({ account_id: admin.id }) }
+  let(:member_token) { JsonWebToken.encode({ account_id: member.id }) }
+  let(:admin_headers) { { "Authorization" => "Bearer #{admin_token}" } }
+  let(:member_headers) { { "Authorization" => "Bearer #{member_token}" } }
+
+  describe "POST /api/tasks/assign/cycle" do
     before do
       @area = create(:area)
       @task = create(:task, area_id: @area.id)
+      # memberにエリアを割り当て、割り当て可能な状態にする
+      member.areas << @area
     end
 
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        post :cycle_create, params: { assign_cycle: { task_id: @task.id } }
-        expect(response).to have_http_status(:ok)
+    context "認証済みadminユーザーの場合" do
+      context "有効なパラメータの場合" do
+        it "Status 201が返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: @task.id } },
+            headers: admin_headers
+          expect(response).to have_http_status(:created)
+        end
+
+        it "AssignCycleが作成されること" do
+          expect {
+            post "/api/tasks/assign/cycle",
+              params: { assign_cycle: { task_id: @task.id } },
+              headers: admin_headers
+          }.to change(AssignCycle, :count).by(1)
+        end
+
+        it "作成されたデータが返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: @task.id } },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["task_id"]).to eq(@task.id)
+          expect(json_response["is_active"]).to be true
+        end
+
+        it "AssignHistoryが作成されること" do
+          expect {
+            post "/api/tasks/assign/cycle",
+              params: { assign_cycle: { task_id: @task.id } },
+              headers: admin_headers
+          }.to change(AssignHistory, :count).by(1)
+        end
       end
 
-      it "AssignCycleが作成されること" do
-        expect {
-          post :cycle_create, params: { assign_cycle: { task_id: @task.id } }
-        }.to change(AssignCycle, :count).by(1)
+      context "既存のサイクルがある場合" do
+        before do
+          @existing_cycle = create(:assign_cycle, task: @task, is_active: true)
+        end
+
+        it "既存のサイクルが非アクティブになること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: @task.id } },
+            headers: admin_headers
+          @existing_cycle.reload
+          expect(@existing_cycle.is_active).to be false
+        end
       end
 
-      it "作成されたデータが返ってくること" do
-        post :cycle_create, params: { assign_cycle: { task_id: @task.id } }
-        json_response = JSON.parse(response.body)
-        expect(json_response["task_id"]).to eq(@task.id)
+      context "task_idが指定されていない場合" do
+        it "Status 422が返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: nil } },
+            headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: nil } },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"].first).to include("タスクID")
+        end
+      end
+
+      context "存在しないtask_idが指定された場合" do
+        it "Status 404が返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: 999999 } },
+            headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: 999999 } },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("タスクが見つかりません")
+        end
+      end
+
+      context "割り当て可能なメンバーがいない場合" do
+        before do
+          # memberからエリアを削除
+          member.areas.clear
+        end
+
+        it "Status 422が返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: @task.id } },
+            headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: @task.id } },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("割り当て可能なメンバーがいません")
+        end
+
+        it "AssignCycleが作成されないこと" do
+          expect {
+            post "/api/tasks/assign/cycle",
+              params: { assign_cycle: { task_id: @task.id } },
+              headers: admin_headers
+          }.not_to change(AssignCycle, :count)
+        end
       end
     end
 
-    context "task_idが指定されていない場合" do
-      it "Status 422が返ってくること" do
-        post :cycle_create, params: { assign_cycle: { task_id: nil } }
-        expect(response).to have_http_status(:unprocessable_entity)
+    context "認証済みmemberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        post "/api/tasks/assign/cycle",
+          params: { assign_cycle: { task_id: @task.id } },
+          headers: member_headers
+        expect(response).to have_http_status(:forbidden)
       end
 
       it "エラーメッセージが返ってくること" do
-        post :cycle_create, params: { assign_cycle: { task_id: nil } }
+        post "/api/tasks/assign/cycle",
+          params: { assign_cycle: { task_id: @task.id } },
+          headers: member_headers
         json_response = JSON.parse(response.body)
-        expect(json_response).to have_key("message")
-        expect(json_response["status"]).to eq(422)
+        expect(json_response["errors"]).to include("権限がありません")
+      end
+
+      it "AssignCycleが作成されないこと" do
+        expect {
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: @task.id } },
+            headers: member_headers
+        }.not_to change(AssignCycle, :count)
       end
     end
 
-    context "存在しないtask_idが指定された場合" do
-      it "Status 422が返ってくること" do
-        post :cycle_create, params: { assign_cycle: { task_id: 999999 } }
-        expect(response).to have_http_status(:unprocessable_entity)
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        post "/api/tasks/assign/cycle",
+          params: { assign_cycle: { task_id: @task.id } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "AssignCycleが作成されないこと" do
+        expect {
+          post "/api/tasks/assign/cycle",
+            params: { assign_cycle: { task_id: @task.id } }
+        }.not_to change(AssignCycle, :count)
       end
     end
   end

--- a/spec/requests/api/assigns_spec.rb
+++ b/spec/requests/api/assigns_spec.rb
@@ -84,6 +84,31 @@ RSpec.describe "Api::Assigns", type: :request do
         end
       end
 
+      context "assign_cycleキーが欠落している場合" do
+        it "Status 400が返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { task_id: @task.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/tasks/assign/cycle",
+            params: { task_id: @task.id },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("Bad request")
+        end
+
+        it "AssignCycleが作成されないこと" do
+          expect {
+            post "/api/tasks/assign/cycle",
+              params: { task_id: @task.id },
+              headers: admin_headers
+          }.not_to change(AssignCycle, :count)
+        end
+      end
+
       context "存在しないtask_idが指定された場合" do
         it "Status 404が返ってくること" do
           post "/api/tasks/assign/cycle",

--- a/spec/services/assigns/cycle_create_spec.rb
+++ b/spec/services/assigns/cycle_create_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Services::Assigns::CycleCreate, type: :service do
         result = service.call(valid_params, admin)
         expect(result.success?).to be false
         expect(result.status).to eq(:unprocessable_entity)
-        expect(result.errors).to include("サイクル作成に失敗しました")
+        expect(result.errors.first).to include("サイクル作成または割り当てに失敗しました")
       end
     end
 

--- a/spec/services/assigns/cycle_create_spec.rb
+++ b/spec/services/assigns/cycle_create_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Assigns::CycleCreate, type: :service do
+  let(:repository) { instance_double(Services::Assigns::Repository) }
+  let(:service) { described_class.new(repository:) }
+
+  describe "#call" do
+    let!(:admin) { create(:account) }
+    let!(:member) { create(:account_member) }
+    let!(:area) { create(:area) }
+    let!(:task) { create(:task, area:) }
+
+    let(:valid_params) { { assign_cycle: { task_id: task.id.to_s } } }
+
+    context "認証されていない場合" do
+      it "unauthorizedを返すこと" do
+        result = service.call(valid_params, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unauthorized)
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "管理者ではない場合" do
+      it "forbiddenを返すこと" do
+        result = service.call(valid_params, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:forbidden)
+        expect(result.errors).to include("権限がありません")
+      end
+    end
+
+    context "Contract検証に失敗した場合" do
+      let(:invalid_params) { { assign_cycle: { task_id: "invalid" } } }
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(invalid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+      end
+
+      it "Contractのエラーメッセージを返すこと" do
+        result = service.call(invalid_params, admin)
+        expect(result.errors.first).to include("タスクIDは正の整数である必要があります")
+      end
+    end
+
+    context "task_idがない場合" do
+      let(:empty_params) { { assign_cycle: { task_id: "" } } }
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(empty_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to include("タスクIDは必須です")
+      end
+    end
+
+    context "Taskが存在しない場合" do
+      let(:not_found_params) { { assign_cycle: { task_id: "999999" } } }
+
+      before do
+        allow(repository).to receive(:find_task_with_lock).with(999999).and_return(nil)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call(not_found_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("タスクが見つかりません")
+      end
+    end
+
+    context "正常にサイクルを作成して割り当てが成功した場合" do
+      let(:new_cycle) { instance_double(AssignCycle, id: 100, task_id: task.id, is_active: true) }
+      let(:assign_result) { instance_double(AssignHistory, account_id: member.id) }
+
+      before do
+        allow(repository).to receive(:find_task_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).with(task).and_return(0)
+        allow(repository).to receive(:create_cycle).with(task).and_return(new_cycle)
+        allow(new_cycle).to receive(:assign).and_return(assign_result)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:created)
+      end
+
+      it "cycleを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.cycle).to eq(new_cycle)
+      end
+
+      it "deactivate_all_cyclesを呼び出すこと" do
+        service.call(valid_params, admin)
+        expect(repository).to have_received(:deactivate_all_cycles).with(task)
+      end
+
+      it "create_cycleを呼び出すこと" do
+        service.call(valid_params, admin)
+        expect(repository).to have_received(:create_cycle).with(task)
+      end
+
+      it "assignを呼び出すこと" do
+        service.call(valid_params, admin)
+        expect(new_cycle).to have_received(:assign)
+      end
+    end
+
+    context "assign_cycleネストなしのパラメータでも正常に動作すること" do
+      let(:flat_params) { { task_id: task.id.to_s } }
+      let(:new_cycle) { instance_double(AssignCycle, id: 100, task_id: task.id, is_active: true) }
+      let(:assign_result) { instance_double(AssignHistory, account_id: member.id) }
+
+      before do
+        allow(repository).to receive(:find_task_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).with(task).and_return(0)
+        allow(repository).to receive(:create_cycle).with(task).and_return(new_cycle)
+        allow(new_cycle).to receive(:assign).and_return(assign_result)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(flat_params, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:created)
+      end
+    end
+
+    context "サイクルは作成されたが割り当てが失敗した場合" do
+      let(:new_cycle) { instance_double(AssignCycle, id: 100) }
+
+      before do
+        allow(repository).to receive(:find_task_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).with(task).and_return(0)
+        allow(repository).to receive(:create_cycle).with(task).and_return(new_cycle)
+        allow(new_cycle).to receive(:assign).and_return(false)
+      end
+
+      it "失敗を返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+      end
+
+      it "エラーメッセージを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.errors).to include("割り当て可能なメンバーがいません")
+      end
+
+      it "cycleがnilであること（トランザクションがロールバックされるため）" do
+        result = service.call(valid_params, admin)
+        expect(result.cycle).to be_nil
+      end
+    end
+
+    context "既存のサイクルがある場合" do
+      let!(:existing_cycle) { create(:assign_cycle, task:, is_active: true) }
+      let(:new_cycle) { instance_double(AssignCycle, id: 100, task_id: task.id, is_active: true) }
+      let(:assign_result) { instance_double(AssignHistory, account_id: member.id) }
+
+      before do
+        allow(repository).to receive(:find_task_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).with(task).and_return(1)
+        allow(repository).to receive(:create_cycle).with(task).and_return(new_cycle)
+        allow(new_cycle).to receive(:assign).and_return(assign_result)
+      end
+
+      it "既存のサイクルを非アクティブ化すること" do
+        service.call(valid_params, admin)
+        expect(repository).to have_received(:deactivate_all_cycles).with(task)
+      end
+    end
+
+    context "Deadlocked例外が発生した場合" do
+      before do
+        allow(repository).to receive(:find_task_with_lock).and_raise(ActiveRecord::Deadlocked.new("Deadlock"))
+      end
+
+      it "service_unavailableを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+        expect(result.errors.first).to include("混雑")
+      end
+    end
+
+    context "LockWaitTimeout例外が発生した場合" do
+      before do
+        allow(repository).to receive(:find_task_with_lock).and_raise(ActiveRecord::LockWaitTimeout.new("Timeout"))
+      end
+
+      it "service_unavailableを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:service_unavailable)
+      end
+    end
+
+    context "RecordInvalid例外が発生した場合" do
+      before do
+        allow(repository).to receive(:find_task_with_lock).with(task.id).and_return(task)
+        allow(repository).to receive(:deactivate_all_cycles).and_raise(ActiveRecord::RecordInvalid.new(task))
+      end
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors).to include("サイクル作成に失敗しました")
+      end
+    end
+
+    context "StatementInvalid例外が発生した場合" do
+      before do
+        allow(repository).to receive(:find_task_with_lock).and_raise(ActiveRecord::StatementInvalid.new("DB Error"))
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+        expect(result.errors).to include("データベースエラーが発生しました")
+      end
+    end
+  end
+
+  describe "依存性注入" do
+    it "デフォルトでRepositoryを使用すること" do
+      service = described_class.new
+      expect(service.instance_variable_get(:@repository)).to be_a(Services::Assigns::Repository)
+    end
+
+    it "カスタムRepositoryを注入できること" do
+      custom_repo = instance_double(Services::Assigns::Repository)
+      service = described_class.new(repository: custom_repo)
+      expect(service.instance_variable_get(:@repository)).to eq(custom_repo)
+    end
+  end
+end

--- a/spec/services/assigns/repository_spec.rb
+++ b/spec/services/assigns/repository_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Assigns::Repository, type: :service do
+  let(:repository) { described_class.new }
+  let!(:area) { create(:area) }
+
+  describe "#find_task_with_lock" do
+    let!(:task) { create(:task, area:) }
+
+    context "存在するIDの場合" do
+      it "タスクを返すこと" do
+        result = repository.find_task_with_lock(task.id)
+        expect(result).to eq(task)
+      end
+    end
+
+    context "存在しないIDの場合" do
+      it "nilを返すこと" do
+        result = repository.find_task_with_lock(999999)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#deactivate_all_cycles" do
+    let!(:task) { create(:task, area:) }
+
+    context "アクティブなサイクルがある場合" do
+      let!(:cycle1) { create(:assign_cycle, task:, is_active: true) }
+      let!(:cycle2) { create(:assign_cycle, task:, is_active: true) }
+
+      it "全てのサイクルを非アクティブ化すること" do
+        repository.deactivate_all_cycles(task)
+
+        expect(cycle1.reload.is_active).to be false
+        expect(cycle2.reload.is_active).to be false
+      end
+
+      it "更新された行数を返すこと" do
+        result = repository.deactivate_all_cycles(task)
+        expect(result).to eq(2)
+      end
+    end
+
+    context "サイクルが存在しない場合" do
+      it "エラーにならないこと" do
+        expect { repository.deactivate_all_cycles(task) }.not_to raise_error
+      end
+
+      it "0を返すこと" do
+        result = repository.deactivate_all_cycles(task)
+        expect(result).to eq(0)
+      end
+    end
+
+    context "他のタスクのサイクルがある場合" do
+      let!(:other_task) { create(:task, area:) }
+      let!(:cycle) { create(:assign_cycle, task:, is_active: true) }
+      let!(:other_cycle) { create(:assign_cycle, task: other_task, is_active: true) }
+
+      it "指定タスクのサイクルのみ非アクティブ化すること" do
+        repository.deactivate_all_cycles(task)
+
+        expect(cycle.reload.is_active).to be false
+        expect(other_cycle.reload.is_active).to be true
+      end
+    end
+  end
+
+  describe "#create_cycle" do
+    let!(:task) { create(:task, area:) }
+
+    it "新しいAssignCycleを作成すること" do
+      expect {
+        repository.create_cycle(task)
+      }.to change(AssignCycle, :count).by(1)
+    end
+
+    it "作成されたAssignCycleを返すこと" do
+      result = repository.create_cycle(task)
+      expect(result).to be_a(AssignCycle)
+      expect(result).to be_persisted
+    end
+
+    it "is_activeがtrueで作成されること" do
+      result = repository.create_cycle(task)
+      expect(result.is_active).to be true
+    end
+
+    it "指定したタスクに紐づくこと" do
+      result = repository.create_cycle(task)
+      expect(result.task_id).to eq(task.id)
+    end
+
+    context "バリデーションエラーが発生した場合" do
+      it "ActiveRecord::RecordInvalidを発生させること" do
+        allow(task).to receive_message_chain(:assign_cycles, :create!).and_raise(ActiveRecord::RecordInvalid.new(AssignCycle.new))
+        expect { repository.create_cycle(task) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Assigns#cycle_create を4層アーキテクチャ（Contract → Service → Repository → Presenter）に移行
- 認証・認可チェックを追加（admin のみ）
- 既存サイクルの非活性化と自動割り当て実行を追加

## 変更ファイル

### 新規作成
- `app/contracts/assigns/cycle_create.rb` - task_id 検証
- `app/services/assigns/repository.rb` - DB操作
- `app/services/assigns/result.rb` - 結果オブジェクト
- `app/services/assigns/cycle_create.rb` - サイクル作成サービス
- `app/presenters/assign_cycle_presenter.rb` - レスポンス整形

### 更新
- `app/controllers/api/assigns_controller.rb` - 4層パターンに修正
- `spec/requests/api/assigns_spec.rb` - 認証・認可テスト追加

## 破壊的変更

| 変更内容 | 影響 |
|----------|------|
| 認証必須化 | 未認証は 401 |
| 認可追加 | admin のみ（member は 403） |
| 既存サイクル非活性化 | 同一タスクの古いサイクルが is_active=false に |
| 自動割り当て | サイクル作成後に自動で割り当て実行 |

## Test plan
- [x] Contract テスト: 26 examples
- [x] Service テスト: 19 examples
- [x] Presenter テスト: 8 examples
- [x] Request テスト: 17 examples
- [x] 全テスト: 1510 examples, 0 failures
- [x] RuboCop: no offenses