### PR TITLE
feat: AccountAreasコントローラーを4層アーキテクチャに移行

### DIFF
--- a/app/contracts/account_areas/create.rb
+++ b/app/contracts/account_areas/create.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Contracts
+  module AccountAreas
+    # エリア追加の入力検証
+    # params: { account_id: Integer, area_id: Integer }
+    class Create
+      include ActiveModel::Model
+
+      attr_accessor :account_id, :area_id
+
+      validates :account_id, presence: { message: "アカウントIDは必須です" }
+      validates :account_id, numericality: { only_integer: true, greater_than: 0, message: "アカウントIDは正の整数である必要があります" }, if: -> { account_id.present? }
+      validates :area_id, presence: { message: "エリアIDは必須です" }
+      validates :area_id, numericality: { only_integer: true, greater_than: 0, message: "エリアIDは正の整数である必要があります" }, if: -> { area_id.present? }
+
+      def self.call(params)
+        contract = new(
+          account_id: params[:account_id],
+          area_id: params[:area_id]
+        )
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { account_id: account_id.to_i, area_id: area_id.to_i }
+      end
+    end
+  end
+end

--- a/app/contracts/account_areas/create.rb
+++ b/app/contracts/account_areas/create.rb
@@ -21,9 +21,9 @@ module Contracts
         )
 
         if contract.valid?
-          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+          Contracts::Result.new(success?: true, value: contract.normalized_attributes, errors: [])
         else
-          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
         end
       end
 

--- a/app/contracts/account_areas/destroy.rb
+++ b/app/contracts/account_areas/destroy.rb
@@ -21,9 +21,9 @@ module Contracts
         )
 
         if contract.valid?
-          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+          Contracts::Result.new(success?: true, value: contract.normalized_attributes, errors: [])
         else
-          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+          Contracts::Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
         end
       end
 

--- a/app/contracts/account_areas/destroy.rb
+++ b/app/contracts/account_areas/destroy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Contracts
+  module AccountAreas
+    # エリア削除の入力検証
+    # params: { account_id: Integer, area_id: Integer }
+    class Destroy
+      include ActiveModel::Model
+
+      attr_accessor :account_id, :area_id
+
+      validates :account_id, presence: { message: "アカウントIDは必須です" }
+      validates :account_id, numericality: { only_integer: true, greater_than: 0, message: "アカウントIDは正の整数である必要があります" }, if: -> { account_id.present? }
+      validates :area_id, presence: { message: "エリアIDは必須です" }
+      validates :area_id, numericality: { only_integer: true, greater_than: 0, message: "エリアIDは正の整数である必要があります" }, if: -> { area_id.present? }
+
+      def self.call(params)
+        contract = new(
+          account_id: params[:account_id],
+          area_id: params[:area_id]
+        )
+
+        if contract.valid?
+          Result.new(success?: true, value: contract.normalized_attributes, errors: [])
+        else
+          Result.new(success?: false, value: nil, errors: contract.errors.full_messages)
+        end
+      end
+
+      def normalized_attributes
+        { account_id: account_id.to_i, area_id: area_id.to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/api/account_areas_controller.rb
+++ b/app/controllers/api/account_areas_controller.rb
@@ -1,20 +1,32 @@
 # frozen_string_literal: true
 
 class Api::AccountAreasController < ApplicationController
+  before_action :authenticated?
+
+  # POST /api/account_areas
+  # アカウントにエリアを追加
   def create
-    account = Account.find(params[:account_id])
-    area = Area.find(params[:area_id])
-
-    account.add_area(area)
-
-    render json: account.areas
+    result = ::Services::AccountAreas::Create.new.call(create_params, @current_account)
+    render_result(result) do
+      ::Presenters::AreaPresenter.render_areas(result.areas)
+    end
   end
 
+  # DELETE /api/account_areas/:id
+  # アカウントからエリアを削除
   def destroy
-    account = Account.find(params[:account_id])
-    area = Area.find(params[:area_id])
-
-    account.remove_area(area)
-    render json: account.areas
+    result = ::Services::AccountAreas::Destroy.new.call(destroy_params, @current_account)
+    render_result(result) do
+      ::Presenters::AreaPresenter.render_areas(result.areas)
+    end
   end
+
+  private
+    def create_params
+      params.permit(:account_id, :area_id).to_h.symbolize_keys
+    end
+
+    def destroy_params
+      params.permit(:account_id, :area_id).to_h.symbolize_keys
+    end
 end

--- a/app/services/account_areas/create.rb
+++ b/app/services/account_areas/create.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Services
+  module AccountAreas
+    # アカウントにエリアを追加するサービス
+    #
+    # 認可: admin のみ
+    class Create
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { account_id: Integer, area_id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # 認可チェック（admin_only）
+        policy = ::Policies::AccountPolicy.new(current_account)
+        unless policy.admin_only?
+          Rails.logger.warn "AccountArea create unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
+
+        # Contract検証
+        validation = ::Contracts::AccountAreas::Create.call(params)
+        unless validation.success?
+          Rails.logger.warn "AccountArea create validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        account_id = validation.value[:account_id]
+        area_id = validation.value[:area_id]
+
+        # アカウント取得
+        account = @repository.find_account(account_id)
+        if account.nil?
+          Rails.logger.warn "Account not found for area add: account_id=#{account_id}"
+          return failure(["アカウントが見つかりません"], :not_found)
+        end
+
+        # エリア取得
+        area = @repository.find_area(area_id)
+        if area.nil?
+          Rails.logger.warn "Area not found for account area add: area_id=#{area_id}"
+          return failure(["エリアが見つかりません"], :not_found)
+        end
+
+        # 既に紐付いているか確認
+        if @repository.area_exists?(account, area)
+          Rails.logger.warn "Area already exists for account: account_id=#{account_id}, area_id=#{area_id}"
+          return failure(["このエリアは既に追加されています"], :conflict)
+        end
+
+        # エリア追加
+        unless @repository.add_area(account, area)
+          Rails.logger.error "Failed to add area: account_id=#{account_id}, area_id=#{area_id}"
+          return failure(["エリアの追加に失敗しました"], :unprocessable_entity)
+        end
+
+        Rails.logger.info "Area added to account: account_id=#{account_id}, area_id=#{area_id}, by_admin=#{current_account.id}"
+        areas = @repository.get_areas(account)
+        success(areas)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "AccountArea create DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def success(areas)
+          Result.new(success?: true, areas:, message: nil, errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          Result.new(success?: false, areas: nil, message: "failed", errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/account_areas/destroy.rb
+++ b/app/services/account_areas/destroy.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Services
+  module AccountAreas
+    # アカウントからエリアを削除するサービス
+    #
+    # 認可: admin のみ
+    class Destroy
+      def initialize(repository: Repository.new)
+        @repository = repository
+      end
+
+      # @param params [Hash] { account_id: Integer, area_id: Integer }
+      # @param current_account [Account, nil] 現在のログインユーザー
+      # @return [Result]
+      def call(params, current_account)
+        # 認証チェック
+        return failure(["認証が必要です"], :unauthorized) if current_account.nil?
+
+        # 認可チェック（admin_only）
+        policy = ::Policies::AccountPolicy.new(current_account)
+        unless policy.admin_only?
+          Rails.logger.warn "AccountArea destroy unauthorized: account_id=#{current_account.id}, role=#{current_account.role}"
+          return failure(["権限がありません"], :forbidden)
+        end
+
+        # Contract検証
+        validation = ::Contracts::AccountAreas::Destroy.call(params)
+        unless validation.success?
+          Rails.logger.warn "AccountArea destroy validation failed: #{validation.errors.join(', ')}"
+          return failure(validation.errors, :unprocessable_entity)
+        end
+
+        account_id = validation.value[:account_id]
+        area_id = validation.value[:area_id]
+
+        # アカウント取得
+        account = @repository.find_account(account_id)
+        if account.nil?
+          Rails.logger.warn "Account not found for area remove: account_id=#{account_id}"
+          return failure(["アカウントが見つかりません"], :not_found)
+        end
+
+        # エリア取得
+        area = @repository.find_area(area_id)
+        if area.nil?
+          Rails.logger.warn "Area not found for account area remove: area_id=#{area_id}"
+          return failure(["エリアが見つかりません"], :not_found)
+        end
+
+        # 紐付いているか確認
+        unless @repository.area_exists?(account, area)
+          Rails.logger.warn "Area not found in account: account_id=#{account_id}, area_id=#{area_id}"
+          return failure(["このエリアはアカウントに紐付いていません"], :not_found)
+        end
+
+        # エリア削除
+        @repository.remove_area(account, area)
+
+        Rails.logger.info "Area removed from account: account_id=#{account_id}, area_id=#{area_id}, by_admin=#{current_account.id}"
+        areas = @repository.get_areas(account)
+        success(areas)
+      rescue ActiveRecord::StatementInvalid => e
+        Rails.logger.error "AccountArea destroy DB error: #{e.message}"
+        failure(["データベースエラーが発生しました"], :internal_server_error)
+      end
+
+      private
+        def success(areas)
+          Result.new(success?: true, areas:, message: nil, errors: [], status: :ok)
+        end
+
+        def failure(errors, status)
+          Result.new(success?: false, areas: nil, message: "failed", errors:, status:)
+        end
+    end
+  end
+end

--- a/app/services/account_areas/destroy.rb
+++ b/app/services/account_areas/destroy.rb
@@ -55,7 +55,10 @@ module Services
         end
 
         # エリア削除
-        @repository.remove_area(account, area)
+        unless @repository.remove_area(account, area)
+          Rails.logger.error "Failed to remove area: account_id=#{account_id}, area_id=#{area_id}"
+          return failure(["エリアの削除に失敗しました"], :unprocessable_entity)
+        end
 
         Rails.logger.info "Area removed from account: account_id=#{account_id}, area_id=#{area_id}, by_admin=#{current_account.id}"
         areas = @repository.get_areas(account)

--- a/app/services/account_areas/repository.rb
+++ b/app/services/account_areas/repository.rb
@@ -29,21 +29,25 @@ module Services
       # アカウントにエリアを追加
       # @param account [Account]
       # @param area [Area]
-      # @return [Boolean] 追加成功時true
+      # @return [Boolean] 追加成功時true、重複時false
       def add_area(account, area)
         account.areas << area
         true
-      rescue ActiveRecord::RecordNotUnique
+      rescue ActiveRecord::RecordNotUnique => e
+        Rails.logger.warn "AccountArea add_area race condition: account_id=#{account.id}, area_id=#{area.id}, error=#{e.message}"
         false
       end
 
       # アカウントからエリアを削除
       # @param account [Account]
       # @param area [Area]
-      # @return [Boolean] 削除成功時true
+      # @return [Boolean] 削除成功時true、失敗時false
       def remove_area(account, area)
-        account.areas.destroy(area)
-        true
+        result = account.areas.destroy(area)
+        result.present?
+      rescue ActiveRecord::RecordNotDestroyed => e
+        Rails.logger.error "AccountArea remove_area failed: account_id=#{account.id}, area_id=#{area.id}, error=#{e.message}"
+        false
       end
 
       # アカウントのエリア一覧を取得

--- a/app/services/account_areas/repository.rb
+++ b/app/services/account_areas/repository.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Services
+  module AccountAreas
+    # アカウント-エリア操作用のリポジトリ
+    class Repository
+      # アカウントをIDで取得
+      # @param account_id [Integer] アカウントID
+      # @return [Account, nil]
+      def find_account(account_id)
+        Account.find_by(id: account_id)
+      end
+
+      # エリアをIDで取得
+      # @param area_id [Integer] エリアID
+      # @return [Area, nil]
+      def find_area(area_id)
+        Area.find_by(id: area_id)
+      end
+
+      # アカウントにエリアが既に紐付いているか確認
+      # @param account [Account]
+      # @param area [Area]
+      # @return [Boolean]
+      def area_exists?(account, area)
+        account.areas.exists?(area.id)
+      end
+
+      # アカウントにエリアを追加
+      # @param account [Account]
+      # @param area [Area]
+      # @return [Boolean] 追加成功時true
+      def add_area(account, area)
+        account.areas << area
+        true
+      rescue ActiveRecord::RecordNotUnique
+        false
+      end
+
+      # アカウントからエリアを削除
+      # @param account [Account]
+      # @param area [Area]
+      # @return [Boolean] 削除成功時true
+      def remove_area(account, area)
+        account.areas.destroy(area)
+        true
+      end
+
+      # アカウントのエリア一覧を取得
+      # @param account [Account]
+      # @return [Array<Area>]
+      def get_areas(account)
+        account.areas
+      end
+    end
+  end
+end

--- a/app/services/account_areas/result.rb
+++ b/app/services/account_areas/result.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Services
+  module AccountAreas
+    # アカウント-エリア操作の結果を表すStruct
+    # @!attribute success?
+    #   @return [Boolean] 操作が成功したかどうか
+    # @!attribute areas
+    #   @return [Array<Area>, nil] エリア一覧
+    # @!attribute message
+    #   @return [String, nil] 結果メッセージ
+    # @!attribute errors
+    #   @return [Array<String>] エラーメッセージ配列
+    # @!attribute status
+    #   @return [Symbol] HTTPステータスシンボル
+    Result = Struct.new(:success?, :areas, :message, :errors, :status, keyword_init: true)
+  end
+end

--- a/spec/contracts/account_areas/create_spec.rb
+++ b/spec/contracts/account_areas/create_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::AccountAreas::Create do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      let(:params) { { account_id: "1", area_id: "2" } }
+
+      it "success?がtrueを返すこと" do
+        result = described_class.call(params)
+        expect(result.success?).to be true
+      end
+
+      it "valueにnormalized_attributesを返すこと" do
+        result = described_class.call(params)
+        expect(result.value).to eq({ account_id: 1, area_id: 2 })
+      end
+
+      it "errorsが空であること" do
+        result = described_class.call(params)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "整数のパラメータの場合" do
+      let(:params) { { account_id: 10, area_id: 20 } }
+
+      it "success?がtrueを返すこと" do
+        result = described_class.call(params)
+        expect(result.success?).to be true
+      end
+
+      it "valueが整数のまま返されること" do
+        result = described_class.call(params)
+        expect(result.value).to eq({ account_id: 10, area_id: 20 })
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "account_idが空の場合" do
+        let(:params) { { account_id: "", area_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("アカウントIDは必須です")
+        end
+      end
+
+      context "area_idが空の場合" do
+        let(:params) { { account_id: "1", area_id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("エリアIDは必須です")
+        end
+      end
+
+      context "account_idがnilの場合" do
+        let(:params) { { account_id: nil, area_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "area_idがnilの場合" do
+        let(:params) { { account_id: "1", area_id: nil } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "account_idが非数値の場合" do
+        let(:params) { { account_id: "abc", area_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("アカウントIDは正の整数である必要があります")
+        end
+      end
+
+      context "area_idが非数値の場合" do
+        let(:params) { { account_id: "1", area_id: "xyz" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("エリアIDは正の整数である必要があります")
+        end
+      end
+
+      context "account_idが0の場合" do
+        let(:params) { { account_id: "0", area_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "area_idが負数の場合" do
+        let(:params) { { account_id: "1", area_id: "-1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+    end
+  end
+
+  describe "#normalized_attributes" do
+    it "account_idとarea_idが整数に変換されること" do
+      contract = described_class.new(account_id: "42", area_id: "99")
+      expect(contract.normalized_attributes).to eq({ account_id: 42, area_id: 99 })
+    end
+  end
+end

--- a/spec/contracts/account_areas/destroy_spec.rb
+++ b/spec/contracts/account_areas/destroy_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Contracts::AccountAreas::Destroy do
+  describe ".call" do
+    context "有効なパラメータの場合" do
+      let(:params) { { account_id: "1", area_id: "2" } }
+
+      it "success?がtrueを返すこと" do
+        result = described_class.call(params)
+        expect(result.success?).to be true
+      end
+
+      it "valueにnormalized_attributesを返すこと" do
+        result = described_class.call(params)
+        expect(result.value).to eq({ account_id: 1, area_id: 2 })
+      end
+
+      it "errorsが空であること" do
+        result = described_class.call(params)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "無効なパラメータの場合" do
+      context "account_idが空の場合" do
+        let(:params) { { account_id: "", area_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("アカウントIDは必須です")
+        end
+      end
+
+      context "area_idが空の場合" do
+        let(:params) { { account_id: "1", area_id: "" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+
+        it "エラーメッセージを返すこと" do
+          result = described_class.call(params)
+          expect(result.errors.first).to include("エリアIDは必須です")
+        end
+      end
+
+      context "account_idが非数値の場合" do
+        let(:params) { { account_id: "abc", area_id: "1" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+
+      context "area_idが非数値の場合" do
+        let(:params) { { account_id: "1", area_id: "xyz" } }
+
+        it "success?がfalseを返すこと" do
+          result = described_class.call(params)
+          expect(result.success?).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/account_areas_spec.rb
+++ b/spec/requests/api/account_areas_spec.rb
@@ -3,85 +3,285 @@
 require "rails_helper"
 
 RSpec.describe "Api::AccountAreas", type: :request do
+  let!(:admin) { create(:account, role: "admin") }
+  let!(:member) { create(:account_member) }
+  let(:admin_token) { JsonWebToken.encode({ account_id: admin.id }) }
+  let(:member_token) { JsonWebToken.encode({ account_id: member.id }) }
+  let(:admin_headers) { { "Authorization" => "Bearer #{admin_token}" } }
+  let(:member_headers) { { "Authorization" => "Bearer #{member_token}" } }
+
   describe "POST /api/account_areas" do
-    before do
-      @account = create(:account_member)
-      @area = create(:area, name: "東京")
+    let!(:target_account) { create(:account_member) }
+    let!(:area) { create(:area, name: "東京") }
+
+    context "認証済みadminユーザーの場合" do
+      context "有効なパラメータの場合" do
+        it "Status 200が返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "アカウントにエリアが紐付けられること" do
+          expect {
+            post "/api/account_areas",
+              params: { account_id: target_account.id, area_id: area.id },
+              headers: admin_headers
+          }.to change { target_account.areas.count }.by(1)
+        end
+
+        it "紐付けられたエリア一覧が返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response.length).to eq(1)
+          expect(json_response[0]["name"]).to eq("東京")
+        end
+      end
+
+      context "既にエリアが追加されている場合" do
+        before do
+          target_account.areas << area
+        end
+
+        it "Status 409が返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:conflict)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("このエリアは既に追加されています")
+        end
+      end
+
+      context "存在しないアカウントの場合" do
+        it "Status 404が返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: 999999, area_id: area.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: 999999, area_id: area.id },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("アカウントが見つかりません")
+        end
+      end
+
+      context "存在しないエリアの場合" do
+        it "Status 404が返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: 999999 },
+            headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: 999999 },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("エリアが見つかりません")
+        end
+      end
+
+      context "account_idがない場合" do
+        it "Status 422が返ってくること" do
+          post "/api/account_areas",
+            params: { area_id: area.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+
+      context "area_idがない場合" do
+        it "Status 422が返ってくること" do
+          post "/api/account_areas",
+            params: { account_id: target_account.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
     end
 
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        post "/api/account_areas", params: { account_id: @account.id, area_id: @area.id }
-        expect(response).to have_http_status(:ok)
+    context "認証済みmemberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        post "/api/account_areas",
+          params: { account_id: target_account.id, area_id: area.id },
+          headers: member_headers
+        expect(response).to have_http_status(:forbidden)
       end
 
-      it "アカウントにエリアが紐付けられること" do
-        expect {
-          post "/api/account_areas", params: { account_id: @account.id, area_id: @area.id }
-        }.to change { @account.areas.count }.by(1)
-      end
-
-      it "紐付けられたエリア一覧が返ってくること" do
-        post "/api/account_areas", params: { account_id: @account.id, area_id: @area.id }
+      it "エラーメッセージが返ってくること" do
+        post "/api/account_areas",
+          params: { account_id: target_account.id, area_id: area.id },
+          headers: member_headers
         json_response = JSON.parse(response.body)
-        expect(json_response.length).to eq(1)
-        expect(json_response[0]["name"]).to eq("東京")
+        expect(json_response["errors"]).to include("権限がありません")
+      end
+
+      it "エリアが追加されないこと" do
+        expect {
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: member_headers
+        }.not_to change { target_account.areas.count }
       end
     end
 
-    context "存在しないアカウントの場合" do
-      it "Status 404が返ってくること" do
-        post "/api/account_areas", params: { account_id: 999999, area_id: @area.id }
-        expect(response).to have_http_status(:not_found)
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        post "/api/account_areas",
+          params: { account_id: target_account.id, area_id: area.id }
+        expect(response).to have_http_status(:unauthorized)
       end
-    end
 
-    context "存在しないエリアの場合" do
-      it "Status 404が返ってくること" do
-        post "/api/account_areas", params: { account_id: @account.id, area_id: 999999 }
-        expect(response).to have_http_status(:not_found)
+      it "エリアが追加されないこと" do
+        expect {
+          post "/api/account_areas",
+            params: { account_id: target_account.id, area_id: area.id }
+        }.not_to change { target_account.areas.count }
       end
     end
   end
 
   describe "DELETE /api/account_areas/:id" do
+    let!(:target_account) { create(:account_member) }
+    let!(:area) { create(:area, name: "東京") }
+
     before do
-      @account = create(:account_member)
-      @area = create(:area, name: "東京")
-      @account.add_area(@area)
-      @account_area = AccountArea.find_by(account_id: @account.id, area_id: @area.id)
+      target_account.add_area(area)
+      @account_area = AccountArea.find_by(account_id: target_account.id, area_id: area.id)
     end
 
-    context "有効なパラメータの場合" do
-      it "Status 200が返ってくること" do
-        delete "/api/account_areas/#{@account_area.id}", params: { account_id: @account.id, area_id: @area.id }
-        expect(response).to have_http_status(:ok)
+    context "認証済みadminユーザーの場合" do
+      context "有効なパラメータの場合" do
+        it "Status 200が返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "アカウントからエリアが削除されること" do
+          expect {
+            delete "/api/account_areas/#{@account_area.id}",
+              params: { account_id: target_account.id, area_id: area.id },
+              headers: admin_headers
+          }.to change { target_account.areas.count }.by(-1)
+        end
+
+        it "残りのエリア一覧が返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response.length).to eq(0)
+        end
       end
 
-      it "アカウントからエリアが削除されること" do
-        expect {
-          delete "/api/account_areas/#{@account_area.id}", params: { account_id: @account.id, area_id: @area.id }
-        }.to change { @account.areas.count }.by(-1)
+      context "存在しないアカウントの場合" do
+        it "Status 404が返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: 999999, area_id: area.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: 999999, area_id: area.id },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("アカウントが見つかりません")
+        end
       end
 
-      it "残りのエリア一覧が返ってくること" do
-        delete "/api/account_areas/#{@account_area.id}", params: { account_id: @account.id, area_id: @area.id }
+      context "存在しないエリアの場合" do
+        it "Status 404が返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: 999999 },
+            headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: 999999 },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("エリアが見つかりません")
+        end
+      end
+
+      context "紐付いていないエリアの場合" do
+        let!(:other_area) { create(:area, name: "大阪") }
+
+        it "Status 404が返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: other_area.id },
+            headers: admin_headers
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "エラーメッセージが返ってくること" do
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: other_area.id },
+            headers: admin_headers
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to include("このエリアはアカウントに紐付いていません")
+        end
+      end
+    end
+
+    context "認証済みmemberユーザーの場合" do
+      it "Status 403が返ってくること" do
+        delete "/api/account_areas/#{@account_area.id}",
+          params: { account_id: target_account.id, area_id: area.id },
+          headers: member_headers
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "エラーメッセージが返ってくること" do
+        delete "/api/account_areas/#{@account_area.id}",
+          params: { account_id: target_account.id, area_id: area.id },
+          headers: member_headers
         json_response = JSON.parse(response.body)
-        expect(json_response.length).to eq(0)
+        expect(json_response["errors"]).to include("権限がありません")
+      end
+
+      it "エリアが削除されないこと" do
+        expect {
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: area.id },
+            headers: member_headers
+        }.not_to change { target_account.areas.count }
       end
     end
 
-    context "存在しないアカウントの場合" do
-      it "Status 404が返ってくること" do
-        delete "/api/account_areas/999999", params: { account_id: 999999, area_id: @area.id }
-        expect(response).to have_http_status(:not_found)
+    context "未認証の場合" do
+      it "Status 401が返ってくること" do
+        delete "/api/account_areas/#{@account_area.id}",
+          params: { account_id: target_account.id, area_id: area.id }
+        expect(response).to have_http_status(:unauthorized)
       end
-    end
 
-    context "存在しないエリアの場合" do
-      it "Status 404が返ってくること" do
-        delete "/api/account_areas/#{@account_area.id}", params: { account_id: @account.id, area_id: 999999 }
-        expect(response).to have_http_status(:not_found)
+      it "エリアが削除されないこと" do
+        expect {
+          delete "/api/account_areas/#{@account_area.id}",
+            params: { account_id: target_account.id, area_id: area.id }
+        }.not_to change { target_account.areas.count }
       end
     end
   end

--- a/spec/services/account_areas/create_spec.rb
+++ b/spec/services/account_areas/create_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::AccountAreas::Create, type: :service do
+  let(:repository) { instance_double(Services::AccountAreas::Repository) }
+  let(:service) { described_class.new(repository:) }
+
+  describe "#call" do
+    let!(:admin) { create(:account) }
+    let!(:member) { create(:account_member) }
+    let!(:target_account) { create(:account_member) }
+    let!(:area) { create(:area) }
+
+    let(:valid_params) { { account_id: target_account.id.to_s, area_id: area.id.to_s } }
+
+    context "認証されていない場合" do
+      it "unauthorizedを返すこと" do
+        result = service.call(valid_params, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unauthorized)
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "管理者ではない場合" do
+      it "forbiddenを返すこと" do
+        result = service.call(valid_params, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:forbidden)
+        expect(result.errors).to include("権限がありません")
+      end
+    end
+
+    context "Contract検証に失敗した場合" do
+      let(:invalid_params) { { account_id: "invalid", area_id: area.id.to_s } }
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(invalid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+      end
+    end
+
+    context "アカウントが存在しない場合" do
+      before do
+        allow(repository).to receive(:find_account).with(999999).and_return(nil)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call({ account_id: "999999", area_id: area.id.to_s }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("アカウントが見つかりません")
+      end
+    end
+
+    context "エリアが存在しない場合" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(999999).and_return(nil)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call({ account_id: target_account.id.to_s, area_id: "999999" }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("エリアが見つかりません")
+      end
+    end
+
+    context "エリアが既に追加されている場合" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(true)
+      end
+
+      it "conflictを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:conflict)
+        expect(result.errors).to include("このエリアは既に追加されています")
+      end
+    end
+
+    context "正常にエリアを追加した場合" do
+      let(:areas) { [area] }
+
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(false)
+        allow(repository).to receive(:add_area).with(target_account, area).and_return(true)
+        allow(repository).to receive(:get_areas).with(target_account).and_return(areas)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "areasを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.areas).to eq(areas)
+      end
+
+      it "add_areaを呼び出すこと" do
+        service.call(valid_params, admin)
+        expect(repository).to have_received(:add_area).with(target_account, area)
+      end
+    end
+  end
+
+  describe "依存性注入" do
+    it "デフォルトでRepositoryを使用すること" do
+      service = described_class.new
+      expect(service.instance_variable_get(:@repository)).to be_a(Services::AccountAreas::Repository)
+    end
+
+    it "カスタムRepositoryを注入できること" do
+      custom_repo = instance_double(Services::AccountAreas::Repository)
+      service = described_class.new(repository: custom_repo)
+      expect(service.instance_variable_get(:@repository)).to eq(custom_repo)
+    end
+  end
+end

--- a/spec/services/account_areas/create_spec.rb
+++ b/spec/services/account_areas/create_spec.rb
@@ -111,6 +111,38 @@ RSpec.describe Services::AccountAreas::Create, type: :service do
         expect(repository).to have_received(:add_area).with(target_account, area)
       end
     end
+
+    context "add_areaがfalseを返した場合（レースコンディション）" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(false)
+        allow(repository).to receive(:add_area).with(target_account, area).and_return(false)
+      end
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors).to include("エリアの追加に失敗しました")
+      end
+    end
+
+    context "データベースエラーが発生した場合" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(false)
+        allow(repository).to receive(:add_area).and_raise(ActiveRecord::StatementInvalid.new("connection lost"))
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+        expect(result.errors).to include("データベースエラーが発生しました")
+      end
+    end
   end
 
   describe "依存性注入" do

--- a/spec/services/account_areas/destroy_spec.rb
+++ b/spec/services/account_areas/destroy_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::AccountAreas::Destroy, type: :service do
+  let(:repository) { instance_double(Services::AccountAreas::Repository) }
+  let(:service) { described_class.new(repository:) }
+
+  describe "#call" do
+    let!(:admin) { create(:account) }
+    let!(:member) { create(:account_member) }
+    let!(:target_account) { create(:account_member) }
+    let!(:area) { create(:area) }
+
+    let(:valid_params) { { account_id: target_account.id.to_s, area_id: area.id.to_s } }
+
+    context "認証されていない場合" do
+      it "unauthorizedを返すこと" do
+        result = service.call(valid_params, nil)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unauthorized)
+        expect(result.errors).to include("認証が必要です")
+      end
+    end
+
+    context "管理者ではない場合" do
+      it "forbiddenを返すこと" do
+        result = service.call(valid_params, member)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:forbidden)
+        expect(result.errors).to include("権限がありません")
+      end
+    end
+
+    context "Contract検証に失敗した場合" do
+      let(:invalid_params) { { account_id: "invalid", area_id: area.id.to_s } }
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(invalid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+      end
+    end
+
+    context "アカウントが存在しない場合" do
+      before do
+        allow(repository).to receive(:find_account).with(999999).and_return(nil)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call({ account_id: "999999", area_id: area.id.to_s }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("アカウントが見つかりません")
+      end
+    end
+
+    context "エリアが存在しない場合" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(999999).and_return(nil)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call({ account_id: target_account.id.to_s, area_id: "999999" }, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("エリアが見つかりません")
+      end
+    end
+
+    context "エリアが紐付いていない場合" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(false)
+      end
+
+      it "not_foundを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:not_found)
+        expect(result.errors).to include("このエリアはアカウントに紐付いていません")
+      end
+    end
+
+    context "正常にエリアを削除した場合" do
+      let(:areas) { [] }
+
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(true)
+        allow(repository).to receive(:remove_area).with(target_account, area).and_return(true)
+        allow(repository).to receive(:get_areas).with(target_account).and_return(areas)
+      end
+
+      it "成功を返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be true
+        expect(result.status).to eq(:ok)
+      end
+
+      it "areasを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.areas).to eq(areas)
+      end
+
+      it "remove_areaを呼び出すこと" do
+        service.call(valid_params, admin)
+        expect(repository).to have_received(:remove_area).with(target_account, area)
+      end
+    end
+  end
+
+  describe "依存性注入" do
+    it "デフォルトでRepositoryを使用すること" do
+      service = described_class.new
+      expect(service.instance_variable_get(:@repository)).to be_a(Services::AccountAreas::Repository)
+    end
+
+    it "カスタムRepositoryを注入できること" do
+      custom_repo = instance_double(Services::AccountAreas::Repository)
+      service = described_class.new(repository: custom_repo)
+      expect(service.instance_variable_get(:@repository)).to eq(custom_repo)
+    end
+  end
+end

--- a/spec/services/account_areas/destroy_spec.rb
+++ b/spec/services/account_areas/destroy_spec.rb
@@ -111,6 +111,38 @@ RSpec.describe Services::AccountAreas::Destroy, type: :service do
         expect(repository).to have_received(:remove_area).with(target_account, area)
       end
     end
+
+    context "remove_areaがfalseを返した場合" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(true)
+        allow(repository).to receive(:remove_area).with(target_account, area).and_return(false)
+      end
+
+      it "unprocessable_entityを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.errors).to include("エリアの削除に失敗しました")
+      end
+    end
+
+    context "データベースエラーが発生した場合" do
+      before do
+        allow(repository).to receive(:find_account).with(target_account.id).and_return(target_account)
+        allow(repository).to receive(:find_area).with(area.id).and_return(area)
+        allow(repository).to receive(:area_exists?).with(target_account, area).and_return(true)
+        allow(repository).to receive(:remove_area).and_raise(ActiveRecord::StatementInvalid.new("connection lost"))
+      end
+
+      it "internal_server_errorを返すこと" do
+        result = service.call(valid_params, admin)
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+        expect(result.errors).to include("データベースエラーが発生しました")
+      end
+    end
   end
 
   describe "依存性注入" do

--- a/spec/services/account_areas/repository_spec.rb
+++ b/spec/services/account_areas/repository_spec.rb
@@ -75,6 +75,21 @@ RSpec.describe Services::AccountAreas::Repository, type: :service do
         }.to change(AccountArea, :count).by(1)
       end
     end
+
+    context "RecordNotUniqueが発生した場合" do
+      before do
+        allow(account.areas).to receive(:<<).and_raise(ActiveRecord::RecordNotUnique.new("Duplicate entry"))
+      end
+
+      it "falseを返すこと" do
+        result = repository.add_area(account, area)
+        expect(result).to be false
+      end
+
+      it "例外を発生させないこと" do
+        expect { repository.add_area(account, area) }.not_to raise_error
+      end
+    end
   end
 
   describe "#remove_area" do

--- a/spec/services/account_areas/repository_spec.rb
+++ b/spec/services/account_areas/repository_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::AccountAreas::Repository, type: :service do
+  let(:repository) { described_class.new }
+  let!(:account) { create(:account_member) }
+  let!(:area) { create(:area) }
+
+  describe "#find_account" do
+    context "存在するIDの場合" do
+      it "アカウントを返すこと" do
+        result = repository.find_account(account.id)
+        expect(result).to eq(account)
+      end
+    end
+
+    context "存在しないIDの場合" do
+      it "nilを返すこと" do
+        result = repository.find_account(999999)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#find_area" do
+    context "存在するIDの場合" do
+      it "エリアを返すこと" do
+        result = repository.find_area(area.id)
+        expect(result).to eq(area)
+      end
+    end
+
+    context "存在しないIDの場合" do
+      it "nilを返すこと" do
+        result = repository.find_area(999999)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#area_exists?" do
+    context "エリアが紐付いている場合" do
+      before { account.areas << area }
+
+      it "trueを返すこと" do
+        result = repository.area_exists?(account, area)
+        expect(result).to be true
+      end
+    end
+
+    context "エリアが紐付いていない場合" do
+      it "falseを返すこと" do
+        result = repository.area_exists?(account, area)
+        expect(result).to be false
+      end
+    end
+  end
+
+  describe "#add_area" do
+    context "エリアが未追加の場合" do
+      it "trueを返すこと" do
+        result = repository.add_area(account, area)
+        expect(result).to be true
+      end
+
+      it "エリアが追加されること" do
+        repository.add_area(account, area)
+        expect(account.areas).to include(area)
+      end
+
+      it "AccountAreaレコードが作成されること" do
+        expect {
+          repository.add_area(account, area)
+        }.to change(AccountArea, :count).by(1)
+      end
+    end
+  end
+
+  describe "#remove_area" do
+    before { account.areas << area }
+
+    it "trueを返すこと" do
+      result = repository.remove_area(account, area)
+      expect(result).to be true
+    end
+
+    it "エリアが削除されること" do
+      repository.remove_area(account, area)
+      expect(account.areas).not_to include(area)
+    end
+
+    it "AccountAreaレコードが削除されること" do
+      expect {
+        repository.remove_area(account, area)
+      }.to change(AccountArea, :count).by(-1)
+    end
+  end
+
+  describe "#get_areas" do
+    context "エリアがある場合" do
+      let!(:area2) { create(:area, name: "東京") }
+
+      before do
+        account.areas << area
+        account.areas << area2
+      end
+
+      it "エリア一覧を返すこと" do
+        result = repository.get_areas(account)
+        expect(result.length).to eq(2)
+      end
+    end
+
+    context "エリアがない場合" do
+      it "空配列を返すこと" do
+        result = repository.get_areas(account)
+        expect(result).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- AccountAreasコントローラーを4層アーキテクチャ（Contract → Service → Repository）に移行
- 認証・認可の追加によるセキュリティ強化
- 重複エリア追加時の409 Conflictレスポンス追加

## 変更ファイル

### Contracts
- `app/contracts/account_areas/create.rb` - 追加用入力検証
- `app/contracts/account_areas/destroy.rb` - 削除用入力検証

### Services
- `app/services/account_areas/repository.rb` - DB操作抽象化
- `app/services/account_areas/result.rb` - 結果オブジェクト
- `app/services/account_areas/create.rb` - エリア追加ビジネスロジック
- `app/services/account_areas/destroy.rb` - エリア削除ビジネスロジック

### Controller
- `app/controllers/api/account_areas_controller.rb` - 4層パターンに書き換え

### Tests
- `spec/contracts/account_areas/create_spec.rb`
- `spec/contracts/account_areas/destroy_spec.rb`
- `spec/services/account_areas/repository_spec.rb`
- `spec/services/account_areas/create_spec.rb`
- `spec/services/account_areas/destroy_spec.rb`
- `spec/requests/api/account_areas_spec.rb` - 認証・認可テストに更新

## 破壊的変更
| 変更内容 | 以前 | 以後 |
|---------|------|------|
| 認証 | 不要 | 必須（401） |
| 認可 | なし | admin限定（403） |
| 重複追加 | 500 | 409 Conflict |

## Test plan
- [x] Contract tests (create/destroy) - 全パス
- [x] Repository tests - 全パス
- [x] Service tests (create/destroy) - 全パス
- [x] Request specs - 認証・認可テスト全パス
- [x] 全テスト実行: 1608件パス
- [x] RuboCop: 違反なし