### PR TITLE
chore: rack-attackによるレート制限を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem "jwt"
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem "rack-cors"
 
+# レート制限（DoS攻撃対策）
+gem "rack-attack"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (3.0.9.1)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-session (2.0.0)
@@ -335,6 +337,7 @@ DEPENDENCIES
   jwt
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-attack
   rack-cors
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-controller-testing

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Rack::Attack設定
+# DoS攻撃・ブルートフォース攻撃対策
+class Rack::Attack
+  ### スロットリング設定 ###
+
+  # 全リクエスト: 1分あたり300リクエストまで（IPアドレスごと）
+  throttle("req/ip", limit: 300, period: 1.minute) do |req|
+    req.ip
+  end
+
+  # ログインエンドポイント: 1分あたり5回まで（ブルートフォース対策）
+  throttle("logins/ip", limit: 5, period: 1.minute) do |req|
+    if req.path == "/api/account/login" && req.post?
+      req.ip
+    end
+  end
+
+  # アカウント作成: 1時間あたり10回まで（スパム対策）
+  throttle("signups/ip", limit: 10, period: 1.hour) do |req|
+    if req.path == "/api/accounts" && req.post?
+      req.ip
+    end
+  end
+
+  ### ブロックリスト ###
+
+  # 環境変数でブロックIPリストを設定可能
+  # BLOCKED_IPS="1.2.3.4,5.6.7.8" の形式
+  blocklist("block bad IPs") do |req|
+    blocked_ips = ENV.fetch("BLOCKED_IPS", "").split(",").map(&:strip)
+    blocked_ips.include?(req.ip)
+  end
+
+  ### セーフリスト ###
+
+  # ヘルスチェックエンドポイントは制限対象外
+  safelist("allow health checks") do |req|
+    req.path == "/health"
+  end
+
+  # ローカル開発環境は制限対象外（開発効率のため）
+  safelist("allow localhost in development") do |req|
+    Rails.env.development? && (req.ip == "127.0.0.1" || req.ip == "::1")
+  end
+
+  ### レスポンスカスタマイズ ###
+
+  # スロットリング時のレスポンス（429 Too Many Requests）
+  self.throttled_responder = lambda do |req|
+    retry_after = (req.env["rack.attack.match_data"] || {})[:period]
+    [
+      429,
+      {
+        "Content-Type" => "application/json",
+        "Retry-After" => retry_after.to_s
+      },
+      [{ errors: ["リクエストが多すぎます。しばらく待ってから再試行してください。"], status: 429 }.to_json]
+    ]
+  end
+
+  # ブロックリスト時のレスポンス（403 Forbidden）
+  self.blocklisted_responder = lambda do |_req|
+    [
+      403,
+      { "Content-Type" => "application/json" },
+      [{ errors: ["アクセスが拒否されました。"], status: 403 }.to_json]
+    ]
+  end
+end
+
+# ログ出力設定
+ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
+  req = payload[:request]
+  Rails.logger.warn "[Rack::Attack] Throttled: #{req.ip} - #{req.path}"
+end
+
+ActiveSupport::Notifications.subscribe("blocklist.rack_attack") do |_name, _start, _finish, _id, payload|
+  req = payload[:request]
+  Rails.logger.warn "[Rack::Attack] Blocked: #{req.ip} - #{req.path}"
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,81 +2,170 @@
 
 # Rack::Attack設定
 # DoS攻撃・ブルートフォース攻撃対策
-class Rack::Attack
-  ### スロットリング設定 ###
+#
+# 本番環境での注意事項:
+# - ECS Fargate等の複数コンテナ環境では、Redisキャッシュストアの設定が必要
+# - 設定例: Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(url: ENV["REDIS_URL"])
+# - デフォルトのファイルストアでは、コンテナ間でカウントが共有されない
 
-  # 全リクエスト: 1分あたり300リクエストまで（IPアドレスごと）
-  throttle("req/ip", limit: 300, period: 1.minute) do |req|
+begin
+  # ブロックIPリストの初期化（起動時に一度だけパース）
+  BLOCKED_IPS = begin
+    raw_ips = ENV.fetch("BLOCKED_IPS", "")
+    if raw_ips.blank?
+      []
+    else
+      ips = raw_ips.split(",").map(&:strip).reject(&:blank?)
+
+      # IPアドレス形式の検証（IPv4, IPv6）
+      valid_ips = []
+      invalid_ips = []
+
+      ips.each do |ip|
+        if ip.match?(/\A(?:\d{1,3}\.){3}\d{1,3}\z/) || ip.match?(/\A[a-fA-F0-9:]+\z/)
+          valid_ips << ip
+        else
+          invalid_ips << ip
+        end
+      end
+
+      if invalid_ips.any?
+        Rails.logger.error "[Rack::Attack] 不正なIP形式が含まれています: #{invalid_ips.join(', ')}"
+      end
+
+      if valid_ips.any?
+        Rails.logger.info "[Rack::Attack] ブロックリスト初期化: #{valid_ips.size}件のIP"
+      end
+
+      valid_ips
+    end
+  end.freeze
+
+  # クライアントIPを安全に取得するヘルパー
+  # ALB/プロキシ経由の場合はX-Forwarded-Forを考慮
+  def self.get_client_ip(req)
+    req.env["action_dispatch.remote_ip"]&.to_s || req.ip
+  rescue StandardError
     req.ip
   end
 
-  # ログインエンドポイント: 1分あたり5回まで（ブルートフォース対策）
-  throttle("logins/ip", limit: 5, period: 1.minute) do |req|
-    if req.path == "/api/account/login" && req.post?
-      req.ip
+  class Rack::Attack
+    ### スロットリング設定 ###
+
+    # 全リクエスト: 1分あたり300リクエストまで（IPアドレスごと）
+    # 通常のブラウジングでは60-100req/min程度を想定
+    throttle("req/ip", limit: 300, period: 1.minute) do |req|
+      req.env["action_dispatch.remote_ip"]&.to_s || req.ip
+    rescue StandardError => e
+      Rails.logger.error "[Rack::Attack] req/ip IP取得エラー: #{e.class}"
+      nil
+    end
+
+    # ログインエンドポイント: 1分あたり5回まで（ブルートフォース対策）
+    throttle("logins/ip", limit: 5, period: 1.minute) do |req|
+      if req.path == "/api/account/login" && req.post?
+        req.env["action_dispatch.remote_ip"]&.to_s || req.ip
+      end
+    rescue StandardError => e
+      Rails.logger.error "[Rack::Attack] logins/ip エラー: #{e.class}"
+      nil
+    end
+
+    # アカウント作成: 1時間あたり10回まで（管理者操作の過負荷防止）
+    throttle("signups/ip", limit: 10, period: 1.hour) do |req|
+      if req.path == "/api/accounts" && req.post?
+        req.env["action_dispatch.remote_ip"]&.to_s || req.ip
+      end
+    rescue StandardError => e
+      Rails.logger.error "[Rack::Attack] signups/ip エラー: #{e.class}"
+      nil
+    end
+
+    ### ブロックリスト ###
+
+    # 環境変数でブロックIPリストを設定可能
+    # BLOCKED_IPS="1.2.3.4,5.6.7.8" の形式
+    blocklist("block bad IPs") do |req|
+      client_ip = req.env["action_dispatch.remote_ip"]&.to_s || req.ip
+      BLOCKED_IPS.include?(client_ip)
+    rescue StandardError => e
+      Rails.logger.error "[Rack::Attack] blocklist エラー: #{e.class}"
+      false
+    end
+
+    ### セーフリスト ###
+
+    # ヘルスチェックエンドポイントは制限対象外
+    safelist("allow health checks") do |req|
+      req.path == "/health"
+    end
+
+    # ローカル開発環境は制限対象外（開発効率のため）
+    safelist("allow localhost in development") do |req|
+      Rails.env.development? && (req.ip == "127.0.0.1" || req.ip == "::1")
+    end
+
+    ### レスポンスカスタマイズ ###
+
+    # スロットリング時のレスポンス（429 Too Many Requests）
+    # Retry-Afterヘッダーで制限解除までの秒数を通知
+    self.throttled_responder = lambda do |req|
+      match_data = req.env["rack.attack.match_data"]
+      retry_after = match_data&.dig(:period) || 60
+
+      [
+        429,
+        {
+          "Content-Type" => "application/json",
+          "Retry-After" => retry_after.to_s
+        },
+        [{ errors: ["リクエストが多すぎます。#{retry_after}秒後に再試行してください。"], status: 429 }.to_json]
+      ]
+    end
+
+    # ブロックリスト時のレスポンス（403 Forbidden）
+    self.blocklisted_responder = lambda do |_req|
+      [
+        403,
+        { "Content-Type" => "application/json" },
+        [{ errors: ["アクセスが拒否されました。"], status: 403 }.to_json]
+      ]
     end
   end
 
-  # アカウント作成: 1時間あたり10回まで（スパム対策）
-  throttle("signups/ip", limit: 10, period: 1.hour) do |req|
-    if req.path == "/api/accounts" && req.post?
-      req.ip
+  # セキュリティイベントのログ出力設定
+  # スロットリング・ブロック発生時にWARNレベルで記録
+  # 注意: IPアドレスはセキュリティ監視目的で記録（GDPR考慮が必要な場合はマスキング検討）
+  ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
+    req = payload[:request]
+    if req
+      client_ip = req.env["action_dispatch.remote_ip"]&.to_s || req.ip
+      Rails.logger.warn "[Rack::Attack] Throttled: #{client_ip} - #{req.path}"
+    else
+      Rails.logger.warn "[Rack::Attack] Throttled: (リクエスト情報取得不可)"
     end
+  rescue StandardError => e
+    Rails.logger.error "[Rack::Attack] Throttleログ出力エラー: #{e.class}"
   end
 
-  ### ブロックリスト ###
-
-  # 環境変数でブロックIPリストを設定可能
-  # BLOCKED_IPS="1.2.3.4,5.6.7.8" の形式
-  blocklist("block bad IPs") do |req|
-    blocked_ips = ENV.fetch("BLOCKED_IPS", "").split(",").map(&:strip)
-    blocked_ips.include?(req.ip)
+  ActiveSupport::Notifications.subscribe("blocklist.rack_attack") do |_name, _start, _finish, _id, payload|
+    req = payload[:request]
+    if req
+      client_ip = req.env["action_dispatch.remote_ip"]&.to_s || req.ip
+      Rails.logger.warn "[Rack::Attack] Blocked: #{client_ip} - #{req.path}"
+    else
+      Rails.logger.warn "[Rack::Attack] Blocked: (リクエスト情報取得不可)"
+    end
+  rescue StandardError => e
+    Rails.logger.error "[Rack::Attack] Blockログ出力エラー: #{e.class}"
   end
 
-  ### セーフリスト ###
+  Rails.logger.info "[Rack::Attack] 初期化完了"
 
-  # ヘルスチェックエンドポイントは制限対象外
-  safelist("allow health checks") do |req|
-    req.path == "/health"
-  end
-
-  # ローカル開発環境は制限対象外（開発効率のため）
-  safelist("allow localhost in development") do |req|
-    Rails.env.development? && (req.ip == "127.0.0.1" || req.ip == "::1")
-  end
-
-  ### レスポンスカスタマイズ ###
-
-  # スロットリング時のレスポンス（429 Too Many Requests）
-  self.throttled_responder = lambda do |req|
-    retry_after = (req.env["rack.attack.match_data"] || {})[:period]
-    [
-      429,
-      {
-        "Content-Type" => "application/json",
-        "Retry-After" => retry_after.to_s
-      },
-      [{ errors: ["リクエストが多すぎます。しばらく待ってから再試行してください。"], status: 429 }.to_json]
-    ]
-  end
-
-  # ブロックリスト時のレスポンス（403 Forbidden）
-  self.blocklisted_responder = lambda do |_req|
-    [
-      403,
-      { "Content-Type" => "application/json" },
-      [{ errors: ["アクセスが拒否されました。"], status: 403 }.to_json]
-    ]
-  end
-end
-
-# ログ出力設定
-ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
-  req = payload[:request]
-  Rails.logger.warn "[Rack::Attack] Throttled: #{req.ip} - #{req.path}"
-end
-
-ActiveSupport::Notifications.subscribe("blocklist.rack_attack") do |_name, _start, _finish, _id, payload|
-  req = payload[:request]
-  Rails.logger.warn "[Rack::Attack] Blocked: #{req.ip} - #{req.path}"
+rescue NameError => e
+  Rails.logger.error "[Rack::Attack] Rack::Attackが利用できません: #{e.message}"
+  raise if Rails.env.production?
+rescue StandardError => e
+  Rails.logger.error "[Rack::Attack] 初期化に失敗しました: #{e.class} - #{e.message}"
+  raise if Rails.env.production?
 end

--- a/spec/initializers/rack_attack_spec.rb
+++ b/spec/initializers/rack_attack_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rack::Attack", type: :request do
+  # テスト用にメモリキャッシュストアを設定
+  before(:all) do
+    @original_cache_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  after(:all) do
+    Rack::Attack.cache.store = @original_cache_store
+  end
+
+  # 各テスト前にキャッシュをクリア
+  before do
+    Rack::Attack.cache.store.clear
+  end
+
+  describe "throttle" do
+    describe "req/ip" do
+      it "300リクエスト/分以内は許可される" do
+        get "/health"
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+    end
+
+    describe "logins/ip" do
+      let(:login_path) { "/api/account/login" }
+      let(:login_params) { { name: "test", password: "password" } }
+
+      it "ログインエンドポイントは5回/分まで許可される" do
+        5.times do
+          post login_path, params: login_params
+        end
+        # 5回までは429にならない（認証失敗の401は別）
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      it "ログインエンドポイントは6回目でthrottleされる" do
+        6.times do
+          post login_path, params: login_params
+        end
+        expect(response).to have_http_status(:too_many_requests)
+      end
+
+      it "throttle時にRetry-Afterヘッダーが返される" do
+        6.times do
+          post login_path, params: login_params
+        end
+        expect(response.headers["Retry-After"]).to be_present
+      end
+
+      it "throttle時にJSONエラーレスポンスが返される" do
+        6.times do
+          post login_path, params: login_params
+        end
+        json = JSON.parse(response.body)
+        expect(json["errors"]).to be_present
+        expect(json["status"]).to eq(429)
+      end
+    end
+
+    describe "signups/ip" do
+      let(:admin) { create(:account, role: "admin") }
+      let(:token) { JsonWebToken.encode(account_id: admin.id) }
+      let(:headers) { { "Authorization" => "Bearer #{token}" } }
+      let(:signup_path) { "/api/accounts" }
+      let(:signup_params) { { account: { name: "newuser", password: "password123", role: "member" } } }
+
+      it "アカウント作成は10回/時まで許可される" do
+        10.times do |i|
+          post signup_path, params: { account: { name: "user#{i}", password: "password123", role: "member" } }, headers:
+        end
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      it "アカウント作成は11回目でthrottleされる" do
+        11.times do |i|
+          post signup_path, params: { account: { name: "user#{i}", password: "password123", role: "member" } }, headers:
+        end
+        expect(response).to have_http_status(:too_many_requests)
+      end
+    end
+  end
+
+  describe "blocklist" do
+    context "BLOCKED_IPSが設定されていない場合" do
+      before do
+        allow(ENV).to receive(:fetch).with("BLOCKED_IPS", "").and_return("")
+      end
+
+      it "リクエストは許可される" do
+        get "/health"
+        expect(response).not_to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "safelist" do
+    it "ヘルスチェックエンドポイントはthrottle対象外" do
+      # 大量リクエストを送信してもthrottleされない
+      100.times { get "/health" }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "レスポンス形式" do
+    let(:login_path) { "/api/account/login" }
+    let(:login_params) { { name: "test", password: "password" } }
+
+    it "throttle時のレスポンスはJSON形式" do
+      6.times { post login_path, params: login_params }
+      expect(response.content_type).to include("application/json")
+    end
+  end
+end
+
+RSpec.describe "BLOCKED_IPS環境変数の解析" do
+  describe "IPアドレス形式の検証" do
+    it "有効なIPv4アドレスを認識する" do
+      expect("192.168.1.1").to match(/\A(?:\d{1,3}\.){3}\d{1,3}\z/)
+    end
+
+    it "有効なIPv6アドレスを認識する" do
+      expect("::1").to match(/\A[a-fA-F0-9:]+\z/)
+      expect("2001:db8::1").to match(/\A[a-fA-F0-9:]+\z/)
+    end
+
+    it "不正な形式は認識しない" do
+      expect("not-an-ip").not_to match(/\A(?:\d{1,3}\.){3}\d{1,3}\z/)
+      expect("not-an-ip").not_to match(/\A[a-fA-F0-9:]+\z/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- rack-attack gem を追加してDoS攻撃・ブルートフォース攻撃対策を実装
- 全リクエスト: 1分あたり300リクエストまで
- ログイン: 1分あたり5回まで（ブルートフォース対策）
- アカウント作成: 1時間あたり10回まで（スパム対策）
- 環境変数 `BLOCKED_IPS` でブロックIPリスト設定可能
- ヘルスチェック・ローカル開発は制限対象外

## Test plan
- [x] RSpec 1710件 Pass
- [ ] 手動テスト: ログインエンドポイントに連続リクエストして429応答を確認