### PR TITLE
perf: N+1クエリ検出ツール（bullet）を導入 (PERF-L01)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,10 +45,11 @@ gem "rack-attack"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ]
-end
+  gem "debug", platforms: %i[mri windows]
 
-group :development, :test do
+  # N+1クエリ検出
+  gem "bullet"
+
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
   gem "solargraph"
@@ -63,7 +64,6 @@ group :development, :test do
 end
 
 group :test do
-  gem "rspec-rails"
   gem "guard"
   gem "simplecov",               require: false
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (8.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -318,6 +321,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uniform_notifier (1.18.0)
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -331,6 +335,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
+  bullet
   debug
   factory_bot_rails
   guard

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,13 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Bullet: N+1クエリ検出設定
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.rails_logger = true      # Railsログに出力
+    Bullet.add_footer = false       # APIモードのためフッター無効
+    Bullet.bullet_logger = true     # log/bullet.logに出力
+    Bullet.raise = false            # 例外は発生させない（ログのみ）
+  end
 end


### PR DESCRIPTION
## Summary
- N+1クエリ検出ツール `bullet` gem を導入
- 開発環境でN+1クエリを自動検出

## 変更内容
- `Gemfile`: bullet gem追加
- `config/environments/development.rb`: Bullet設定追加

## Bullet設定
| 設定 | 値 | 説明 |
|------|-----|------|
| `enable` | true | 有効化 |
| `rails_logger` | true | Railsログに出力 |
| `bullet_logger` | true | log/bullet.logに出力 |
| `add_footer` | false | APIモードのためフッター無効 |
| `raise` | false | 例外発生なし（ログのみ） |

## 確認結果
- RSpec: 1723テスト全Pass
- RuboCop: 287ファイル違反なし

## 関連タスク
- PERF-L01: N+1クエリ監視ツールの導入