### PR TITLE
refactor: AssignCycleの冗長なself削除とscopeへの変換（REF-L01, REF-L02）

### DIFF
--- a/app/models/assign_cycle.rb
+++ b/app/models/assign_cycle.rb
@@ -26,21 +26,17 @@ class AssignCycle < ApplicationRecord
   end
 
   def completed
-    self.deactivation
+    deactivation
     target = AssignHistory.joins(:assign_cycle)
-                .where(assign_cycles: { id: self.id })
+                .where(assign_cycles: { id: })
                 .where(ng: false)
     target.completed
   end
 
   def deactivation
-    self.update(is_active: false)
+    update(is_active: false)
   end
 
-  class << self
-    def unfulfilleds
-      targets = AssignCycle.where(is_active: true)
-      targets
-    end
-  end
+  # アクティブな割り当てサイクルを取得
+  scope :unfulfilleds, -> { where(is_active: true) }
 end


### PR DESCRIPTION
## Summary

- **REF-L01**: `AssignCycle#deactivation`の冗長な`self`削除
- **REF-L02**: `AssignCycle.unfulfilleds`クラスメソッドをscopeに変換

## 変更内容

### REF-L01: 冗長なself削除
```ruby
# Before
self.update(is_active: false)
self.deactivation
self.id

# After
update(is_active: false)
deactivation
id
```

### REF-L02: scopeへの変換
```ruby
# Before
class << self
  def unfulfilleds
    targets = AssignCycle.where(is_active: true)
    targets
  end
end

# After
scope :unfulfilleds, -> { where(is_active: true) }
```

## Test plan

- [x] `bundle exec rspec spec/models/assign_cycle_spec.rb` - 14件Pass
- [x] `bundle exec rspec spec/services/tasks/repository_spec.rb` - Pass
- [x] `bundle exec rspec spec/services/tasks/unfulfilleds_count_spec.rb` - Pass
- [x] `bundle exec rubocop app/models/assign_cycle.rb` - 違反なし